### PR TITLE
fix(idp-app): config sealed secrets annotation

### DIFF
--- a/charts/idp-app/Chart.yaml
+++ b/charts/idp-app/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: idp-app
 description: Base chart
 type: application
-version: 1.3.0
+version: 1.3.1

--- a/charts/idp-app/templates/configs.yaml
+++ b/charts/idp-app/templates/configs.yaml
@@ -10,13 +10,14 @@ apiVersion: bitnami.com/v1alpha1
 kind: SealedSecret
 metadata:
   name: {{ include "idp-app.configName" (list $ $configKey) }}
+  {{- $annotations := merge (dict) (default $configSpec.annotations dict) }}
+  {{- if .scope }}
+  {{- $annotations = merge $annotations (dict (printf "sealedsecrets.bitnami.com/%s" .scope ) "true")}}
+  {{- end }}
+  {{- with $annotations }}
   annotations:
-    {{- with .scope }}
-    sealedsecrets.bitnami.com/{{ . }}: "true"
-    {{- end }}
-    {{- with $configSpec.annotations }}
     {{- toYaml . | nindent 4 }}
-    {{- end }}
+  {{- end }}
   labels:
     {{- include "idp-app.labels" $ | nindent 4 }}
 spec:
@@ -25,13 +26,10 @@ spec:
   template:
     metadata:
       name: {{ include "idp-app.configName" (list $ $configKey) }}
+      {{- with $annotations }}
       annotations:
-        {{- with .scope }}
-        sealedsecrets.bitnami.com/{{ . }}: "true"
-        {{- end }}
-        {{- with $configSpec.annotations }}
         {{- toYaml . | nindent 8 }}
-        {{- end }}
+      {{- end }}
       labels:
         {{- include "idp-app.labels" $ | nindent 8 }}
 {{- end }}

--- a/charts/idp-app/tests/configs-sealedsecrets_test.yaml
+++ b/charts/idp-app/tests/configs-sealedsecrets_test.yaml
@@ -88,8 +88,11 @@ tests:
             encryptedData:
               key1: encryptedvalue1
     asserts:
-      - equal:
+      - notExists:
           path: metadata.annotations
-          value: null
+        template: configs.yaml
+        documentIndex: 0
+      - notExists:
+          path: spec.template.metadata.annotations
         template: configs.yaml
         documentIndex: 0


### PR DESCRIPTION
Annotation should not be set to null when no are needed.