### PR TITLE
fix(idp-app): deployment.staticIps endpointslices

### DIFF
--- a/charts/idp-app/Chart.yaml
+++ b/charts/idp-app/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: idp-app
 description: Base chart
 type: application
-version: 1.4.2
+version: 1.4.3

--- a/charts/idp-app/templates/service.yaml
+++ b/charts/idp-app/templates/service.yaml
@@ -42,10 +42,10 @@ ports:
     protocol: {{ $.Values.service.targetPortProtocol | default "TCP" }}
     port: {{ required "service.targetPort required" $.Values.service.targetPort }}
 endpoints:
-  {{- range $ip := $deployment.staticIps }}
   - addresses:
-      - {{ $ip | quote }}
-  {{- end }}
+      {{ toYaml $deployment.staticIps | nindent 6 }}
+    conditions:
+      ready: true
 ---
 {{- end }}
 {{- end }}

--- a/charts/idp-app/tests/__snapshot__/service-static-ips_test.yaml.snap
+++ b/charts/idp-app/tests/__snapshot__/service-static-ips_test.yaml.snap
@@ -22,8 +22,9 @@ should generate EndpointSlices:
     endpoints:
       - addresses:
           - 192.168.88.4
-      - addresses:
           - 192.168.88.5
+        conditions:
+          ready: true
     kind: EndpointSlice
     metadata:
       labels:
@@ -58,8 +59,9 @@ when multi deployment:
     endpoints:
       - addresses:
           - 192.168.88.4
-      - addresses:
           - 192.168.88.5
+        conditions:
+          ready: true
     kind: EndpointSlice
     metadata:
       labels:
@@ -93,8 +95,9 @@ when multi deployment:
     endpoints:
       - addresses:
           - 192.168.88.4
-      - addresses:
           - 192.168.88.5
+        conditions:
+          ready: true
     kind: EndpointSlice
     metadata:
       labels:
@@ -129,8 +132,9 @@ when multi deployment with overwrite:
     endpoints:
       - addresses:
           - 192.168.88.4
-      - addresses:
           - 192.168.88.5
+        conditions:
+          ready: true
     kind: EndpointSlice
     metadata:
       labels:
@@ -164,6 +168,8 @@ when multi deployment with overwrite:
     endpoints:
       - addresses:
           - 192.168.100.1
+        conditions:
+          ready: true
     kind: EndpointSlice
     metadata:
       labels:


### PR DESCRIPTION
Set endpoints condition to ready otherwise it's ignored by traefik. https://kubernetes.io/docs/concepts/services-networking/endpoint-slices/#ready

Multiple addresses are part of one endpoint set.