### PR TITLE
feat(idp-app)!: nodePools

### DIFF
--- a/charts/idp-app-config/Chart.yaml
+++ b/charts/idp-app-config/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: idp-app-config
 description: idp-app config
 type: application
-version: 2.0.0
+version: 3.0.0

--- a/charts/idp-app-config/values.yaml
+++ b/charts/idp-app-config/values.yaml
@@ -9,8 +9,15 @@ global:
         #aws_region: eu-central-1
         domains:
           example.com: example.com
-        nodeSelector: {}
-        tolerations: {}
+        nodePools:
+          test1:
+            nodeSelector:
+              environment: test
+            tolerations:
+              - key: environment
+                operator: Equal
+                value: test
+                effect: NoSchedule
 
     defaults:
       imageRepository: docker.io

--- a/charts/idp-app/Chart.yaml
+++ b/charts/idp-app/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: idp-app
 description: Base chart
 type: application
-version: 2.1.0
+version: 3.0.0

--- a/charts/idp-app/templates/cronjob.yaml
+++ b/charts/idp-app/templates/cronjob.yaml
@@ -1,5 +1,6 @@
 {{- if not $.Values.debug -}}
 {{- if $.Values.cronjob.enabled }}
+{{- $this := $.Values.cronjob }}
 {{- $deployments := (dict "" dict) }}
 {{- range $deploymentKey, $deployment := $deployments }}
 {{- $deploymentName := include "idp-app.deploymentName" (list $ $deploymentKey) }}
@@ -9,18 +10,21 @@ metadata:
   name: {{ $deploymentName }}
   labels:
     {{- include "idp-app.labels" $ | nindent 4 }}
-  {{- with $.Values.cronjob.annotations }}
+  {{- with $this.annotations }}
   annotations:
-    {{- toYaml $.Values.cronjob.annotations | nindent 4 }}
+    {{- toYaml $this.annotations | nindent 4 }}
   {{- end }}
 spec:
-  schedule: {{ required "cronjob.schedule required" $.Values.cronjob.schedule | quote }}
-  concurrencyPolicy: {{ $.Values.cronjob.concurrencyPolicy | required "cronjob.concurrencyPolicy required" | quote }}
-  {{- if $.Values.cronjob.startingDeadlineSeconds }}
-  startingDeadlineSeconds: {{ $.Values.cronjob.startingDeadlineSeconds }}
+  schedule: {{ required "cronjob.schedule required" $this.schedule | quote }}
+  {{- if hasKey $this "suspend" }}
+  suspend: {{ $this.suspend }}
   {{- end }}
-  successfulJobsHistoryLimit: {{ $.Values.cronjob.successfulJobsHistoryLimit }}
-  failedJobsHistoryLimit: {{ $.Values.cronjob.failedJobsHistoryLimit }}
+  concurrencyPolicy: {{ $this.concurrencyPolicy | required "cronjob.concurrencyPolicy required" | quote }}
+  {{- if $this.startingDeadlineSeconds }}
+  startingDeadlineSeconds: {{ $this.startingDeadlineSeconds }}
+  {{- end }}
+  successfulJobsHistoryLimit: {{ $this.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ $this.failedJobsHistoryLimit }}
   jobTemplate:
     metadata:
       labels:

--- a/charts/idp-app/templates/job.yaml
+++ b/charts/idp-app/templates/job.yaml
@@ -30,8 +30,25 @@ spec:
   {{- if hasKey $this "parallelism" }}
   parallelism: {{ $this.parallelism }}
   {{- end }}
+  {{- if hasKey $this "suspend" }}
+  suspend: {{ $this.suspend }}
+  {{- end }}
+  {{- if hasKey $this "podReplacementPolicy" }}
+  podReplacementPolicy: {{ $this.podReplacementPolicy }}
+  {{- end }}
   {{- if hasKey $this "ttlSecondsAfterFinished" }}
   ttlSecondsAfterFinished: {{ $this.ttlSecondsAfterFinished }}
+  {{- end }}
+  {{- if hasKey $this "podFailurePolicy" }}
+  podFailurePolicy:
+    {{- toYaml $this.podFailurePolicy | nindent 4 }}
+  {{- end }}
+  {{- if hasKey $this "successPolicy" }}
+  successPolicy:
+    {{- toYaml $this.successPolicy | nindent 4 }}
+  {{- end }}
+  {{- if hasKey $this "backoffLimitPerIndex" }}
+  backoffLimitPerIndex: {{ $this.backoffLimitPerIndex }}
   {{- end }}
   template:
     {{- include "idp-app.podTemplate" (list $ $deploymentKey $deployment ) | nindent 4 }}

--- a/charts/idp-app/tests/__snapshot__/configs-sealedsecrets_test.yaml.snap
+++ b/charts/idp-app/tests/__snapshot__/configs-sealedsecrets_test.yaml.snap
@@ -84,18 +84,13 @@ when sealedSecret is specified (with content too), then generate SealedSecret, d
                   readOnly: true
                   subPath: key1
           enableServiceLinks: false
-          nodeSelector:
-            environment: test
+          nodeSelector: null
           securityContext:
             sysctls:
               - name: net.ipv4.ip_unprivileged_port_start
                 value: "0"
           serviceAccountName: RELEASE-NAME
-          tolerations:
-            - effect: NoSchedule
-              key: environment
-              operator: Equal
-              value: test
+          tolerations: null
           topologySpreadConstraints:
             - labelSelector:
                 matchLabels:

--- a/charts/idp-app/tests/__snapshot__/configs_test.yaml.snap
+++ b/charts/idp-app/tests/__snapshot__/configs_test.yaml.snap
@@ -405,18 +405,13 @@ should match snapshot with values-ci.yaml:
                   cpu: 100m
                   memory: 128Mi
           enableServiceLinks: false
-          nodeSelector:
-            environment: test
+          nodeSelector: null
           securityContext:
             sysctls:
               - name: net.ipv4.ip_unprivileged_port_start
                 value: "0"
           serviceAccountName: RELEASE-NAME-resource-suffix
-          tolerations:
-            - effect: NoSchedule
-              key: environment
-              operator: Equal
-              value: test
+          tolerations: null
           topologySpreadConstraints:
             - labelSelector:
                 matchLabels:

--- a/charts/idp-app/tests/__snapshot__/cronjob_test.yaml.snap
+++ b/charts/idp-app/tests/__snapshot__/cronjob_test.yaml.snap
@@ -49,19 +49,14 @@ when cronjob enabled:
                       cpu: 100m
                       memory: 128Mi
               enableServiceLinks: false
-              nodeSelector:
-                environment: test
+              nodeSelector: null
               restartPolicy: OnFailure
               securityContext:
                 sysctls:
                   - name: net.ipv4.ip_unprivileged_port_start
                     value: "0"
               serviceAccountName: RELEASE-NAME
-              tolerations:
-                - effect: NoSchedule
-                  key: environment
-                  operator: Equal
-                  value: test
+              tolerations: null
               topologySpreadConstraints:
                 - labelSelector:
                     matchLabels:

--- a/charts/idp-app/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/idp-app/tests/__snapshot__/deployment_test.yaml.snap
@@ -222,18 +222,13 @@ should match snapshot with values-ci.yaml:
                   cpu: 100m
                   memory: 128Mi
           enableServiceLinks: false
-          nodeSelector:
-            environment: test
+          nodeSelector: null
           securityContext:
             sysctls:
               - name: net.ipv4.ip_unprivileged_port_start
                 value: "0"
           serviceAccountName: RELEASE-NAME-resource-suffix
-          tolerations:
-            - effect: NoSchedule
-              key: environment
-              operator: Equal
-              value: test
+          tolerations: null
           topologySpreadConstraints:
             - labelSelector:
                 matchLabels:
@@ -330,18 +325,13 @@ when multi deployment:
                   cpu: 100m
                   memory: 128Mi
           enableServiceLinks: false
-          nodeSelector:
-            environment: test
+          nodeSelector: null
           securityContext:
             sysctls:
               - name: net.ipv4.ip_unprivileged_port_start
                 value: "0"
           serviceAccountName: RELEASE-NAME
-          tolerations:
-            - effect: NoSchedule
-              key: environment
-              operator: Equal
-              value: test
+          tolerations: null
           topologySpreadConstraints:
             - labelSelector:
                 matchLabels:
@@ -402,18 +392,13 @@ when multi deployment:
                   cpu: 100m
                   memory: 128Mi
           enableServiceLinks: false
-          nodeSelector:
-            environment: test
+          nodeSelector: null
           securityContext:
             sysctls:
               - name: net.ipv4.ip_unprivileged_port_start
                 value: "0"
           serviceAccountName: RELEASE-NAME
-          tolerations:
-            - effect: NoSchedule
-              key: environment
-              operator: Equal
-              value: test
+          tolerations: null
           topologySpreadConstraints:
             - labelSelector:
                 matchLabels:

--- a/charts/idp-app/tests/__snapshot__/job_test.yaml.snap
+++ b/charts/idp-app/tests/__snapshot__/job_test.yaml.snap
@@ -12,9 +12,27 @@ given full supported spec values:
     spec:
       activeDeadlineSeconds: 100
       backoffLimit: 5
+      backoffLimitPerIndex: 3
       completionMode: Indexed
       completions: 3
       parallelism: 2
+      podFailurePolicy:
+        rules:
+          - action: FailJob
+            onExitCodes:
+              containerName: main
+              operator: In
+              values:
+                - 42
+          - action: Ignore
+            onPodConditions:
+              - type: DisruptionTarget
+      podReplacementPolicy: Failed
+      successPolicy:
+        rules:
+          - succeededCount: 1
+            succeededIndexes: 0,2-3
+      suspend: true
       template:
         metadata:
           labels:
@@ -44,19 +62,14 @@ given full supported spec values:
                   cpu: 100m
                   memory: 128Mi
           enableServiceLinks: false
-          nodeSelector:
-            environment: test
+          nodeSelector: null
           restartPolicy: OnFailure
           securityContext:
             sysctls:
               - name: net.ipv4.ip_unprivileged_port_start
                 value: "0"
           serviceAccountName: RELEASE-NAME
-          tolerations:
-            - effect: NoSchedule
-              key: environment
-              operator: Equal
-              value: test
+          tolerations: null
           topologySpreadConstraints:
             - labelSelector:
                 matchLabels:
@@ -115,19 +128,14 @@ when job enabled:
                   cpu: 100m
                   memory: 128Mi
           enableServiceLinks: false
-          nodeSelector:
-            environment: test
+          nodeSelector: null
           restartPolicy: OnFailure
           securityContext:
             sysctls:
               - name: net.ipv4.ip_unprivileged_port_start
                 value: "0"
           serviceAccountName: RELEASE-NAME
-          tolerations:
-            - effect: NoSchedule
-              key: environment
-              operator: Equal
-              value: test
+          tolerations: null
           topologySpreadConstraints:
             - labelSelector:
                 matchLabels:

--- a/charts/idp-app/tests/cronjob_test.yaml
+++ b/charts/idp-app/tests/cronjob_test.yaml
@@ -34,6 +34,7 @@ tests:
         startingDeadlineSeconds: 30
         failedJobsHistoryLimit: 10
         successfulJobsHistoryLimit: 5
+        suspend: true
     asserts:
       - isSubset:
           path: spec
@@ -42,6 +43,7 @@ tests:
             startingDeadlineSeconds: 30
             failedJobsHistoryLimit: 10
             successfulJobsHistoryLimit: 5
+            suspend: true
   - it: when annotations are set
     values:
       - values/cronjob.yaml

--- a/charts/idp-app/tests/deployment_test.yaml
+++ b/charts/idp-app/tests/deployment_test.yaml
@@ -13,23 +13,23 @@ tests:
           imageRepository: private
     asserts:
       - matchSnapshot: {}
-  - it: when nodoCapacity.type = OnDemand
+  - it: when nodePool is set
     values:
       - values/deployment.yaml
     set:
-      nodeCapacity:
-        type: OnDemand
+      nodePool: test1
     asserts:
-      - equal:
-          path: spec.template.spec.nodeSelector.capacity
-          value: on-demand
+      - isSubset:
+          path: spec.template.spec.nodeSelector
+          content:
+            environment: test
       - contains:
           path: spec.template.spec.tolerations
           content:
             effect: NoSchedule
-            key: capacity
+            key: environment
             operator: Equal
-            value: on-demand
+            value: test
   - it: when terminationGracePeriodSeconds is set
     values:
       - values/deployment.yaml

--- a/charts/idp-app/tests/job_test.yaml
+++ b/charts/idp-app/tests/job_test.yaml
@@ -20,6 +20,23 @@ tests:
         completions: 3
         parallelism: 2
         ttlSecondsAfterFinished: 3600
+        backoffLimitPerIndex: 3
+        podReplacementPolicy: "Failed"
+        suspend: true
+        successPolicy:
+          rules:
+            - succeededIndexes: 0,2-3
+              succeededCount: 1
+        podFailurePolicy:
+          rules:
+            - action: FailJob
+              onExitCodes:
+                containerName: main      # optional
+                operator: In             # one of: In, NotIn
+                values: [ 42 ]
+            - action: Ignore             # one of: Ignore, FailJob, Count
+              onPodConditions:
+                - type: DisruptionTarget   # indicates Pod disruption
     asserts:
       - matchSnapshot: { }
   - it: default restartPolicy

--- a/charts/idp-app/tests/values/minimum.yaml
+++ b/charts/idp-app/tests/values/minimum.yaml
@@ -11,13 +11,15 @@ global:
         aws_region: eu-central-1
         domains:
           example.com: example.com
-        nodeSelector:
-          environment: test
-        tolerations:
-          - key: environment
-            operator: Equal
-            value: test
-            effect: NoSchedule
+        nodePools:
+          test1:
+            nodeSelector:
+              environment: test
+            tolerations:
+              - key: environment
+                operator: Equal
+                value: test
+                effect: NoSchedule
     defaults:
       imageRepository: private
       imagePullPolicy: IfNotPresent

--- a/charts/idp-app/values-ci.yaml
+++ b/charts/idp-app/values-ci.yaml
@@ -13,13 +13,15 @@ global:
         aws_region: eu-central-1
         domains:
           example.com: example.com
-        nodeSelector:
-          environment: test
-        tolerations:
-          - key: environment
-            operator: Equal
-            value: test
-            effect: NoSchedule
+        nodePools:
+          test1:
+            nodeSelector:
+              environment: test
+            tolerations:
+              - key: environment
+                operator: Equal
+                value: test
+                effect: NoSchedule
 
     defaults:
       imageRepository: private

--- a/charts/idp-app/values.yaml
+++ b/charts/idp-app/values.yaml
@@ -10,11 +10,9 @@ affinity: {}
 #terminationGracePeriodSeconds: 30
 restartPolicy: null
 
-# Spot / OnDemand
-nodeCapacity:
-  type: Spot
-
+nodePool: null
 nodeSelector: {}
+tolerations: []
 
 topologySpreadConstraints:
   zone: true


### PR DESCRIPTION
BREAKING CHANGE: remove nodeCapacity, use nodePool instead.

To migrate:
When nodeCapacity.type=OnDemand is specified, use nodePool=on-demand instead (if specified for the cluster)

Ability to specify custom nodeSelector/tolerations for the pod.

Implement more job/cronjob spec config.