### PR TITLE
feat(idp-app): treafik ingress route

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,3 @@ A general-purpose Helm chart for deploying any Kubernetes workload — Deploymen
 It is designed to be used directly or as a dependency inside an umbrella chart.
 
 [Read more](charts/idp-app/README.md)
-
-# AI Agents
-
-## Skills
-
-* [helm-chart-developer](https://github.com/matuszeman/agents/tree/main/skills/helm-chart-developer)

--- a/charts/idp-app/Chart.yaml
+++ b/charts/idp-app/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: idp-app
 description: Base chart
 type: application
-version: 5.10.1
+version: 5.11.0

--- a/charts/idp-app/templates/configs.yaml
+++ b/charts/idp-app/templates/configs.yaml
@@ -7,8 +7,6 @@
 {{- $mergedLabels := merge (dict) (include "idp-app.labels" $ | fromYaml) (default $configSpec.labels dict) }}
 {{- $mergedAnnotations := merge (dict) $defaultsConfigsAnnotations (default $configSpec.annotations dict) }}
 {{- if or .fromSecret .fromConfigMap .fromFolder }}
-{{- else if (kindIs "map" .secret) }}
-{{ include "idp-app.renderConfigFromContent" (list $ $configKey $configSpec) }}
 {{- else if .sealedSecret }}
 {{- with .sealedSecret }}
 ---
@@ -77,8 +75,10 @@ spec:
         version: uuid/{{ . | toString }}
         {{- end }}
 {{- end }}
+{{- else if (kindIs "map" .secret) }}
+{{ include "idp-app.renderConfigFromContent" (list $ $configKey $configSpec) }}
 {{- else }}
-{{- $_ := required (printf "configs.%s.content required (or set .fromSecret, .fromConfigMap, .fromFolder)" $configKey) .content }}
+{{- $_ := required (printf "configs.%s.content required (or set .fromSecret, .fromConfigMap, .fromFolder, .secret, .sealedSecret, .awsSecret)" $configKey) .content }}
 {{ include "idp-app.renderConfigFromContent" (list $ $configKey $configSpec) }}
 {{- end }}
 {{- end }}

--- a/charts/idp-app/templates/traefik-ingress-route.yaml
+++ b/charts/idp-app/templates/traefik-ingress-route.yaml
@@ -1,0 +1,114 @@
+{{- if not $.Values.debug -}}
+{{- range $routeKey, $routeSpec := $.Values.traefikIngressRoutes }}
+{{- if $routeSpec.enabled }}
+{{- $route := mustMergeOverwrite (deepCopy $.Values.global.idpAppConfig.defaults.traefikIngressRoute) (deepCopy $routeSpec) }}
+{{- $entryPoint := fromYaml (include "idp-app.clusterConfigMapValue" (list $ "traefikEntryPoints" $route.entryPointName)) }}
+{{- $deployments := default (dict "" dict) $.Values.deployment.multi }}
+{{- range $deploymentKey, $deployment := $deployments }}
+{{- $deploymentName := include "idp-app.deploymentName" (list $ $deploymentKey) }}
+{{- $backendRef := dict }}
+{{- if and $.Values.service.enabled $route.service }}
+{{- fail "traefikIngressRoute: both service.enabled and traefikIngressRoute.service is set" }}
+{{- else if $.Values.service.enabled }}
+{{- $backendRef = dict "name" $deploymentName "port" (default "app" $.Values.service.port) }}
+{{- else if $route.service }}
+{{- $backendRef = deepCopy $route.service }}
+{{- else }}
+{{- fail "traefikIngressRoute: service must be enabled" }}
+{{- end }}
+{{- $routeName := join "-" (compact (list $deploymentName $routeKey)) }}
+{{- $host := "" }}
+{{- if $route.domain }}
+{{- $domain := include "idp-app.clusterConfigMapValue" (list $ "domains" $route.domain) }}
+{{- $host = (include "idp-app.resolveHostFromDomain" (list $route.host $domain)) | replace "__DEPLOYMENT_ID__" $deploymentKey }}
+{{- else }}
+{{- $host = ($route.host | required "traefikIngressRoute: host or domain required") | replace "__DEPLOYMENT_ID__" $deploymentKey }}
+{{- end }}
+{{- $pathFunc := "" }}
+{{- $pathType := $route.pathType | default "PathPrefix" }}
+{{- if eq $pathType "PathPrefix" }}
+{{- $pathFunc = printf "PathPrefix(`%s`)" ($route.path | required "traefikIngressRoute: path required") }}
+{{- else if eq $pathType "Exact" }}
+{{- $pathFunc = printf "Path(`%s`)" ($route.path | required "traefikIngressRoute: path required") }}
+{{- else if eq $pathType "RegularExpression" }}
+{{- $pathFunc = printf "PathRegexp(`%s`)" ($route.path | required "traefikIngressRoute: path required") }}
+{{- else }}
+{{- fail (printf "traefikIngressRoute: unsupported pathType '%s'" $pathType) }}
+{{- end }}
+{{- $matchRule := printf "Host(`%s`) && %s" $host $pathFunc }}
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: {{ $routeName }}
+  labels:
+    {{- include "idp-app.labelsMulti" (list $ $deploymentKey) | nindent 4 }}
+    {{- with $entryPoint.labelSelector }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- if $route.annotations }}
+  annotations:
+    {{- toYaml $route.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  entryPoints:
+    {{- toYaml $entryPoint.entryPoints | nindent 4 }}
+  routes:
+    - match: {{ $matchRule }}
+      kind: Rule
+      services:
+        - name: {{ tpl ($backendRef.name | required "traefikIngressRoute: service.name required") $ | quote }}
+          port: {{ $backendRef.port | required "traefikIngressRoute: service.port required" }}
+      {{- $middlewareList := list }}
+      {{- if and $route.forwardAuth $route.forwardAuth.enabled }}
+      {{- $middlewareList = append $middlewareList (dict "name" (printf "%s-%s-forwardauth" (include "idp-app.fullname" $) $routeKey)) }}
+      {{- end }}
+      {{- range $route.middlewares }}
+      {{- $middlewareList = append $middlewareList . }}
+      {{- end }}
+      {{- if $middlewareList }}
+      middlewares:
+        {{- toYaml $middlewareList | nindent 8 }}
+      {{- end }}
+  {{- if kindIs "map" $entryPoint.tls }}
+  tls:
+    {{- if $entryPoint.tls }}
+    {{- toYaml $entryPoint.tls | nindent 4 }}
+    {{- end }}
+  {{- end }}
+---
+{{- end }}
+{{- if and $route.forwardAuth $route.forwardAuth.enabled }}
+{{- $forwardAuthApp := include "idp-app.clusterConfigMapValue" (list $ "apps" $route.forwardAuth.appName) | fromYaml }}
+{{- $traefikConfig := $forwardAuthApp.traefik.forwardAuthMiddleware | required "forwardAuth: app.traefik.forwardAuthMiddleware required" }}
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ include "idp-app.fullname" $ }}-{{ $routeKey }}-forwardauth
+  labels:
+    {{- include "idp-app.labels" $ | nindent 4 }}
+    {{- with $entryPoint.labelSelector }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- if $route.annotations }}
+  annotations:
+    {{- toYaml $route.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  forwardAuth:
+    address: "{{ $traefikConfig.address }}{{ if $route.forwardAuth.allowedGroups }}?allowed_groups={{ join "," $route.forwardAuth.allowedGroups }}{{ end }}"
+    {{- if $traefikConfig.trustForwardHeader }}
+    trustForwardHeader: {{ $traefikConfig.trustForwardHeader }}
+    {{- end }}
+    {{- if $traefikConfig.authResponseHeaders }}
+    authResponseHeaders:
+      {{- toYaml $traefikConfig.authResponseHeaders | nindent 6 }}
+    {{- end }}
+    {{- if $traefikConfig.authRequestHeaders }}
+    authRequestHeaders:
+      {{- toYaml $traefikConfig.authRequestHeaders | nindent 6 }}
+    {{- end }}
+---
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/idp-app/templates/traefik-ingress-route.yaml
+++ b/charts/idp-app/templates/traefik-ingress-route.yaml
@@ -45,9 +45,14 @@ metadata:
     {{- with $entryPoint.labelSelector }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- if $route.annotations }}
+  {{- if or $route.annotations $entryPoint.annotationSelector }}
   annotations:
-    {{- toYaml $route.annotations | nindent 4 }}
+    {{- with $entryPoint.annotationSelector }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with $route.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- end }}
 spec:
   entryPoints:
@@ -69,10 +74,14 @@ spec:
       middlewares:
         {{- toYaml $middlewareList | nindent 8 }}
       {{- end }}
-  {{- if kindIs "map" $entryPoint.tls }}
+  {{- if kindIs "map" $route.tls }}
   tls:
-    {{- if $entryPoint.tls }}
-    {{- toYaml $entryPoint.tls | nindent 4 }}
+    {{- if $route.tlsOption }}
+    options:
+      name: {{ include "idp-app.fullname" $ }}-{{ $routeKey }}
+    {{- end }}
+    {{- if $route.tls }}
+    {{- toYaml $route.tls | nindent 4 }}
     {{- end }}
   {{- end }}
 ---
@@ -89,9 +98,14 @@ metadata:
     {{- with $entryPoint.labelSelector }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- if $route.annotations }}
+  {{- if or $route.annotations $entryPoint.annotationSelector }}
   annotations:
-    {{- toYaml $route.annotations | nindent 4 }}
+    {{- with $entryPoint.annotationSelector }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with $route.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- end }}
 spec:
   forwardAuth:
@@ -108,6 +122,66 @@ spec:
       {{- toYaml $traefikConfig.authRequestHeaders | nindent 6 }}
     {{- end }}
 ---
+{{- end }}
+{{- if $route.tlsOption }}
+{{- $tlsOptionSpec := deepCopy $route.tlsOption }}
+{{- $clientAuthSecrets := dict }}
+{{- if and $tlsOptionSpec.clientAuth $tlsOptionSpec.clientAuth.secrets }}
+{{- $clientAuthSecrets = $tlsOptionSpec.clientAuth.secrets }}
+{{- $clientAuth := deepCopy $tlsOptionSpec.clientAuth }}
+{{- $_ := unset $clientAuth "secrets" }}
+{{- $secretNames := default list $clientAuth.secretNames }}
+{{- range $secretKey, $secretData := $clientAuthSecrets }}
+{{- $secretNames = append $secretNames (printf "%s-%s-mtls-%s" (include "idp-app.fullname" $) $routeKey $secretKey) }}
+{{- end }}
+{{- $_ := set $clientAuth "secretNames" $secretNames }}
+{{- $_ := set $tlsOptionSpec "clientAuth" $clientAuth }}
+{{- end }}
+apiVersion: traefik.io/v1alpha1
+kind: TLSOption
+metadata:
+  name: {{ include "idp-app.fullname" $ }}-{{ $routeKey }}
+  labels:
+    {{- include "idp-app.labels" $ | nindent 4 }}
+    {{- with $entryPoint.labelSelector }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- if or $route.annotations $entryPoint.annotationSelector }}
+  annotations:
+    {{- with $entryPoint.annotationSelector }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with $route.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  {{- toYaml $tlsOptionSpec | nindent 2 }}
+---
+{{- range $secretKey, $secretData := $clientAuthSecrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "idp-app.fullname" $ }}-{{ $routeKey }}-mtls-{{ $secretKey }}
+  labels:
+    {{- include "idp-app.labels" $ | nindent 4 }}
+    {{- with $entryPoint.labelSelector }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- if or $route.annotations $entryPoint.annotationSelector }}
+  annotations:
+    {{- with $entryPoint.annotationSelector }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with $route.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+type: Opaque
+stringData:
+  {{- toYaml $secretData | nindent 2 }}
+---
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/idp-app/templates/traefik-ingress-route.yaml
+++ b/charts/idp-app/templates/traefik-ingress-route.yaml
@@ -1,20 +1,24 @@
 {{- if not $.Values.debug -}}
-{{- range $routeKey, $routeSpec := $.Values.traefikIngressRoutes }}
+{{- range $routeKey, $routeSpec := $.Values.ingressRoutes }}
 {{- if $routeSpec.enabled }}
-{{- $route := mustMergeOverwrite (deepCopy $.Values.global.idpAppConfig.defaults.traefikIngressRoute) (deepCopy $routeSpec) }}
-{{- $entryPoint := fromYaml (include "idp-app.clusterConfigMapValue" (list $ "traefikEntryPoints" $route.entryPointName)) }}
+{{- $route := mustMergeOverwrite (deepCopy $.Values.global.idpAppConfig.defaults.ingressRoute) (deepCopy $routeSpec) }}
+{{- $gateway := fromYaml (include "idp-app.clusterConfigMapValue" (list $ "httpGateways" $route.gatewayName)) }}
+{{- $gatewayController := $gateway.controller | required "global.idpAppConfig.httpGateways.NAME.controller required" }}
+{{- if ne $gatewayController "traefik" }}
+{{- fail (printf "ingressRoute: gateway '%s' has controller '%s', only 'traefik' is supported" $route.gatewayName $gatewayController) }}
+{{- end }}
 {{- $deployments := default (dict "" dict) $.Values.deployment.multi }}
 {{- range $deploymentKey, $deployment := $deployments }}
 {{- $deploymentName := include "idp-app.deploymentName" (list $ $deploymentKey) }}
 {{- $backendRef := dict }}
 {{- if and $.Values.service.enabled $route.service }}
-{{- fail "traefikIngressRoute: both service.enabled and traefikIngressRoute.service is set" }}
+{{- fail "ingressRoute: both service.enabled and ingressRoute.service is set" }}
 {{- else if $.Values.service.enabled }}
 {{- $backendRef = dict "name" $deploymentName "port" (default "app" $.Values.service.port) }}
 {{- else if $route.service }}
 {{- $backendRef = deepCopy $route.service }}
 {{- else }}
-{{- fail "traefikIngressRoute: service must be enabled" }}
+{{- fail "ingressRoute: service must be enabled" }}
 {{- end }}
 {{- $routeName := join "-" (compact (list $deploymentName $routeKey)) }}
 {{- $host := "" }}
@@ -22,18 +26,18 @@
 {{- $domain := include "idp-app.clusterConfigMapValue" (list $ "domains" $route.domain) }}
 {{- $host = (include "idp-app.resolveHostFromDomain" (list $route.host $domain)) | replace "__DEPLOYMENT_ID__" $deploymentKey }}
 {{- else }}
-{{- $host = ($route.host | required "traefikIngressRoute: host or domain required") | replace "__DEPLOYMENT_ID__" $deploymentKey }}
+{{- $host = ($route.host | required "ingressRoute: host or domain required") | replace "__DEPLOYMENT_ID__" $deploymentKey }}
 {{- end }}
 {{- $pathFunc := "" }}
 {{- $pathType := $route.pathType | default "PathPrefix" }}
 {{- if eq $pathType "PathPrefix" }}
-{{- $pathFunc = printf "PathPrefix(`%s`)" ($route.path | required "traefikIngressRoute: path required") }}
+{{- $pathFunc = printf "PathPrefix(`%s`)" ($route.path | required "ingressRoute: path required") }}
 {{- else if eq $pathType "Exact" }}
-{{- $pathFunc = printf "Path(`%s`)" ($route.path | required "traefikIngressRoute: path required") }}
+{{- $pathFunc = printf "Path(`%s`)" ($route.path | required "ingressRoute: path required") }}
 {{- else if eq $pathType "RegularExpression" }}
-{{- $pathFunc = printf "PathRegexp(`%s`)" ($route.path | required "traefikIngressRoute: path required") }}
+{{- $pathFunc = printf "PathRegexp(`%s`)" ($route.path | required "ingressRoute: path required") }}
 {{- else }}
-{{- fail (printf "traefikIngressRoute: unsupported pathType '%s'" $pathType) }}
+{{- fail (printf "ingressRoute: unsupported pathType '%s'" $pathType) }}
 {{- end }}
 {{- $matchRule := printf "Host(`%s`) && %s" $host $pathFunc }}
 apiVersion: traefik.io/v1alpha1
@@ -42,12 +46,12 @@ metadata:
   name: {{ $routeName }}
   labels:
     {{- include "idp-app.labelsMulti" (list $ $deploymentKey) | nindent 4 }}
-    {{- with $entryPoint.labelSelector }}
+    {{- with $gateway.labelSelector }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- if or $route.annotations $entryPoint.annotationSelector }}
+  {{- if or $route.annotations $gateway.annotationSelector }}
   annotations:
-    {{- with $entryPoint.annotationSelector }}
+    {{- with $gateway.annotationSelector }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
     {{- with $route.annotations }}
@@ -56,13 +60,13 @@ metadata:
   {{- end }}
 spec:
   entryPoints:
-    {{- toYaml $entryPoint.entryPoints | nindent 4 }}
+    {{- toYaml $gateway.entryPoints | nindent 4 }}
   routes:
     - match: {{ $matchRule }}
       kind: Rule
       services:
-        - name: {{ tpl ($backendRef.name | required "traefikIngressRoute: service.name required") $ | quote }}
-          port: {{ $backendRef.port | required "traefikIngressRoute: service.port required" }}
+        - name: {{ tpl ($backendRef.name | required "ingressRoute: service.name required") $ | quote }}
+          port: {{ $backendRef.port | required "ingressRoute: service.port required" }}
       {{- $middlewareList := list }}
       {{- if and $route.forwardAuth $route.forwardAuth.enabled }}
       {{- $middlewareList = append $middlewareList (dict "name" (printf "%s-%s-forwardauth" (include "idp-app.fullname" $) $routeKey)) }}
@@ -95,12 +99,12 @@ metadata:
   name: {{ include "idp-app.fullname" $ }}-{{ $routeKey }}-forwardauth
   labels:
     {{- include "idp-app.labels" $ | nindent 4 }}
-    {{- with $entryPoint.labelSelector }}
+    {{- with $gateway.labelSelector }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- if or $route.annotations $entryPoint.annotationSelector }}
+  {{- if or $route.annotations $gateway.annotationSelector }}
   annotations:
-    {{- with $entryPoint.annotationSelector }}
+    {{- with $gateway.annotationSelector }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
     {{- with $route.annotations }}
@@ -143,12 +147,12 @@ metadata:
   name: {{ include "idp-app.fullname" $ }}-{{ $routeKey }}
   labels:
     {{- include "idp-app.labels" $ | nindent 4 }}
-    {{- with $entryPoint.labelSelector }}
+    {{- with $gateway.labelSelector }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- if or $route.annotations $entryPoint.annotationSelector }}
+  {{- if or $route.annotations $gateway.annotationSelector }}
   annotations:
-    {{- with $entryPoint.annotationSelector }}
+    {{- with $gateway.annotationSelector }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
     {{- with $route.annotations }}
@@ -165,12 +169,12 @@ metadata:
   name: {{ include "idp-app.fullname" $ }}-{{ $routeKey }}-mtls-{{ $secretKey }}
   labels:
     {{- include "idp-app.labels" $ | nindent 4 }}
-    {{- with $entryPoint.labelSelector }}
+    {{- with $gateway.labelSelector }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- if or $route.annotations $entryPoint.annotationSelector }}
+  {{- if or $route.annotations $gateway.annotationSelector }}
   annotations:
-    {{- with $entryPoint.annotationSelector }}
+    {{- with $gateway.annotationSelector }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
     {{- with $route.annotations }}

--- a/charts/idp-app/tests/__snapshot__/example-comprehensive_test.yaml.snap
+++ b/charts/idp-app/tests/__snapshot__/example-comprehensive_test.yaml.snap
@@ -331,3 +331,24 @@ should match snapshot:
         app.kubernetes.io/name: my-app
         app.kubernetes.io/version: 1.2.3
       name: RELEASE-NAME
+  12: |
+    apiVersion: traefik.io/v1alpha1
+    kind: IngressRoute
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: my-app
+        app.kubernetes.io/version: 1.2.3
+      name: RELEASE-NAME-public
+    spec:
+      entryPoints:
+        - websecure
+      routes:
+        - kind: Rule
+          match: Host(`my-app.example.com`) && PathPrefix(`/`)
+          services:
+            - name: RELEASE-NAME
+              port: 80
+      tls:
+        secretName: wildcard-tls

--- a/charts/idp-app/tests/__snapshot__/example-multi-deployment_test.yaml.snap
+++ b/charts/idp-app/tests/__snapshot__/example-multi-deployment_test.yaml.snap
@@ -400,3 +400,75 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME-worker
         app.kubernetes.io/name: my-app
       type: ClusterIP
+  13: |
+    apiVersion: traefik.io/v1alpha1
+    kind: IngressRoute
+    metadata:
+      annotations:
+        traefik.io/controller: traefik-private
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME-api
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: my-app
+        app.kubernetes.io/version: 1.0.0
+        traefik.io/controller: traefik-private
+      name: RELEASE-NAME-api-public
+    spec:
+      entryPoints:
+        - websecure
+      routes:
+        - kind: Rule
+          match: Host(`api.example.com`) && PathPrefix(`/`)
+          services:
+            - name: RELEASE-NAME-api
+              port: 80
+      tls:
+        secretName: wildcard-example-com-tls
+  14: |
+    apiVersion: traefik.io/v1alpha1
+    kind: IngressRoute
+    metadata:
+      annotations:
+        traefik.io/controller: traefik-private
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME-scheduler
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: my-app
+        app.kubernetes.io/version: 1.0.0
+        traefik.io/controller: traefik-private
+      name: RELEASE-NAME-scheduler-public
+    spec:
+      entryPoints:
+        - websecure
+      routes:
+        - kind: Rule
+          match: Host(`scheduler.example.com`) && PathPrefix(`/`)
+          services:
+            - name: RELEASE-NAME-scheduler
+              port: 80
+      tls:
+        secretName: wildcard-example-com-tls
+  15: |
+    apiVersion: traefik.io/v1alpha1
+    kind: IngressRoute
+    metadata:
+      annotations:
+        traefik.io/controller: traefik-private
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME-worker
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: my-app
+        app.kubernetes.io/version: 1.0.0
+        traefik.io/controller: traefik-private
+      name: RELEASE-NAME-worker-public
+    spec:
+      entryPoints:
+        - websecure
+      routes:
+        - kind: Rule
+          match: Host(`worker.example.com`) && PathPrefix(`/`)
+          services:
+            - name: RELEASE-NAME-worker
+              port: 80
+      tls:
+        secretName: wildcard-example-com-tls

--- a/charts/idp-app/tests/__snapshot__/traefik-ingress-route_test.yaml.snap
+++ b/charts/idp-app/tests/__snapshot__/traefik-ingress-route_test.yaml.snap
@@ -3,6 +3,8 @@ multi support:
     apiVersion: traefik.io/v1alpha1
     kind: IngressRoute
     metadata:
+      annotations:
+        traefik.io/controller: traefik-private
       labels:
         app.kubernetes.io/instance: RELEASE-NAME-one
         app.kubernetes.io/managed-by: Helm
@@ -19,11 +21,14 @@ multi support:
           services:
             - name: RELEASE-NAME-one
               port: 80
-      tls: null
+      tls:
+        secretName: wildcard-example-com-tls
   2: |
     apiVersion: traefik.io/v1alpha1
     kind: IngressRoute
     metadata:
+      annotations:
+        traefik.io/controller: traefik-private
       labels:
         app.kubernetes.io/instance: RELEASE-NAME-two
         app.kubernetes.io/managed-by: Helm
@@ -40,12 +45,15 @@ multi support:
           services:
             - name: RELEASE-NAME-two
               port: 80
-      tls: null
+      tls:
+        secretName: wildcard-example-com-tls
 should create IngressRoute:
   1: |
     apiVersion: traefik.io/v1alpha1
     kind: IngressRoute
     metadata:
+      annotations:
+        traefik.io/controller: traefik-private
       labels:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
@@ -62,12 +70,15 @@ should create IngressRoute:
           services:
             - name: RELEASE-NAME
               port: 80
-      tls: null
+      tls:
+        secretName: wildcard-example-com-tls
 should create IngressRoute with Exact pathType:
   1: |
     apiVersion: traefik.io/v1alpha1
     kind: IngressRoute
     metadata:
+      annotations:
+        traefik.io/controller: traefik-private
       labels:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
@@ -84,12 +95,15 @@ should create IngressRoute with Exact pathType:
           services:
             - name: RELEASE-NAME
               port: 80
-      tls: null
+      tls:
+        secretName: wildcard-example-com-tls
 should create IngressRoute with RegularExpression pathType:
   1: |
     apiVersion: traefik.io/v1alpha1
     kind: IngressRoute
     metadata:
+      annotations:
+        traefik.io/controller: traefik-private
       labels:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
@@ -106,12 +120,15 @@ should create IngressRoute with RegularExpression pathType:
           services:
             - name: RELEASE-NAME
               port: 80
-      tls: null
+      tls:
+        secretName: wildcard-example-com-tls
 should support external service backend:
   1: |
     apiVersion: traefik.io/v1alpha1
     kind: IngressRoute
     metadata:
+      annotations:
+        traefik.io/controller: traefik-private
       labels:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
@@ -128,12 +145,15 @@ should support external service backend:
           services:
             - name: my-external-svc
               port: 8080
-      tls: null
+      tls:
+        secretName: wildcard-example-com-tls
 when forwardAuth enabled, should add middleware and generate Middleware resource:
   1: |
     apiVersion: traefik.io/v1alpha1
     kind: IngressRoute
     metadata:
+      annotations:
+        traefik.io/controller: traefik-private
       labels:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
@@ -152,11 +172,14 @@ when forwardAuth enabled, should add middleware and generate Middleware resource
           services:
             - name: RELEASE-NAME
               port: 80
-      tls: null
+      tls:
+        secretName: wildcard-example-com-tls
   2: |
     apiVersion: traefik.io/v1alpha1
     kind: Middleware
     metadata:
+      annotations:
+        traefik.io/controller: traefik-private
       labels:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
@@ -178,6 +201,8 @@ when host is FQDN (no domain), should use host directly:
     apiVersion: traefik.io/v1alpha1
     kind: IngressRoute
     metadata:
+      annotations:
+        traefik.io/controller: traefik-private
       labels:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
@@ -194,4 +219,121 @@ when host is FQDN (no domain), should use host directly:
           services:
             - name: RELEASE-NAME
               port: 80
-      tls: null
+      tls:
+        secretName: wildcard-example-com-tls
+when tlsOption clientAuth uses only secretNames, should reference existing secrets:
+  1: |
+    apiVersion: traefik.io/v1alpha1
+    kind: IngressRoute
+    metadata:
+      annotations:
+        traefik.io/controller: traefik-private
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: app-name
+        app.kubernetes.io/version: 0.1.0
+        traefik.io/controller: traefik-private
+      name: RELEASE-NAME-public
+    spec:
+      entryPoints:
+        - websecure
+      routes:
+        - kind: Rule
+          match: Host(`test.example.com`) && PathPrefix(`/`)
+          services:
+            - name: RELEASE-NAME
+              port: 80
+      tls:
+        options:
+          name: RELEASE-NAME-public
+        secretName: wildcard-example-com-tls
+  2: |
+    apiVersion: traefik.io/v1alpha1
+    kind: TLSOption
+    metadata:
+      annotations:
+        traefik.io/controller: traefik-private
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: app-name
+        app.kubernetes.io/version: 0.1.0
+        traefik.io/controller: traefik-private
+      name: RELEASE-NAME-public
+    spec:
+      clientAuth:
+        clientAuthType: VerifyClientCertIfGiven
+        secretNames:
+          - existing-ca-secret
+          - another-ca-secret
+      minVersion: VersionTLS12
+when tlsOption is set, should generate TLSOption and reference it in IngressRoute:
+  1: |
+    apiVersion: traefik.io/v1alpha1
+    kind: IngressRoute
+    metadata:
+      annotations:
+        traefik.io/controller: traefik-private
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: app-name
+        app.kubernetes.io/version: 0.1.0
+        traefik.io/controller: traefik-private
+      name: RELEASE-NAME-public
+    spec:
+      entryPoints:
+        - websecure
+      routes:
+        - kind: Rule
+          match: Host(`test.example.com`) && PathPrefix(`/`)
+          services:
+            - name: RELEASE-NAME
+              port: 80
+      tls:
+        options:
+          name: RELEASE-NAME-public
+        secretName: wildcard-example-com-tls
+  2: |
+    apiVersion: traefik.io/v1alpha1
+    kind: TLSOption
+    metadata:
+      annotations:
+        traefik.io/controller: traefik-private
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: app-name
+        app.kubernetes.io/version: 0.1.0
+        traefik.io/controller: traefik-private
+      name: RELEASE-NAME-public
+    spec:
+      cipherSuites:
+        - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+      clientAuth:
+        clientAuthType: VerifyClientCertIfGiven
+        secretNames:
+          - RELEASE-NAME-public-mtls-ca1
+      maxVersion: VersionTLS13
+      minVersion: VersionTLS12
+      sniStrict: true
+  3: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      annotations:
+        traefik.io/controller: traefik-private
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: app-name
+        app.kubernetes.io/version: 0.1.0
+        traefik.io/controller: traefik-private
+      name: RELEASE-NAME-public-mtls-ca1
+    stringData:
+      ca.crt: |
+        -----BEGIN CERTIFICATE-----
+        MIIBkTCB+wIJAL2BqG0EXAMPLE
+        -----END CERTIFICATE-----
+    type: Opaque

--- a/charts/idp-app/tests/__snapshot__/traefik-ingress-route_test.yaml.snap
+++ b/charts/idp-app/tests/__snapshot__/traefik-ingress-route_test.yaml.snap
@@ -1,0 +1,197 @@
+multi support:
+  1: |
+    apiVersion: traefik.io/v1alpha1
+    kind: IngressRoute
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME-one
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: app-name
+        app.kubernetes.io/version: 0.1.0
+        traefik.io/controller: traefik-private
+      name: RELEASE-NAME-one-public
+    spec:
+      entryPoints:
+        - websecure
+      routes:
+        - kind: Rule
+          match: Host(`one.example.com`) && PathPrefix(`/`)
+          services:
+            - name: RELEASE-NAME-one
+              port: 80
+      tls: null
+  2: |
+    apiVersion: traefik.io/v1alpha1
+    kind: IngressRoute
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME-two
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: app-name
+        app.kubernetes.io/version: 0.1.0
+        traefik.io/controller: traefik-private
+      name: RELEASE-NAME-two-public
+    spec:
+      entryPoints:
+        - websecure
+      routes:
+        - kind: Rule
+          match: Host(`two.example.com`) && PathPrefix(`/`)
+          services:
+            - name: RELEASE-NAME-two
+              port: 80
+      tls: null
+should create IngressRoute:
+  1: |
+    apiVersion: traefik.io/v1alpha1
+    kind: IngressRoute
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: app-name
+        app.kubernetes.io/version: 0.1.0
+        traefik.io/controller: traefik-private
+      name: RELEASE-NAME-public
+    spec:
+      entryPoints:
+        - websecure
+      routes:
+        - kind: Rule
+          match: Host(`test.example.com`) && PathPrefix(`/`)
+          services:
+            - name: RELEASE-NAME
+              port: 80
+      tls: null
+should create IngressRoute with Exact pathType:
+  1: |
+    apiVersion: traefik.io/v1alpha1
+    kind: IngressRoute
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: app-name
+        app.kubernetes.io/version: 0.1.0
+        traefik.io/controller: traefik-private
+      name: RELEASE-NAME-public
+    spec:
+      entryPoints:
+        - websecure
+      routes:
+        - kind: Rule
+          match: Host(`test.example.com`) && Path(`/exact`)
+          services:
+            - name: RELEASE-NAME
+              port: 80
+      tls: null
+should create IngressRoute with RegularExpression pathType:
+  1: |
+    apiVersion: traefik.io/v1alpha1
+    kind: IngressRoute
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: app-name
+        app.kubernetes.io/version: 0.1.0
+        traefik.io/controller: traefik-private
+      name: RELEASE-NAME-public
+    spec:
+      entryPoints:
+        - websecure
+      routes:
+        - kind: Rule
+          match: Host(`test.example.com`) && PathRegexp(`/api/v[0-9]+`)
+          services:
+            - name: RELEASE-NAME
+              port: 80
+      tls: null
+should support external service backend:
+  1: |
+    apiVersion: traefik.io/v1alpha1
+    kind: IngressRoute
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: app-name
+        app.kubernetes.io/version: 0.1.0
+        traefik.io/controller: traefik-private
+      name: RELEASE-NAME-public
+    spec:
+      entryPoints:
+        - websecure
+      routes:
+        - kind: Rule
+          match: Host(`test.example.com`) && PathPrefix(`/`)
+          services:
+            - name: my-external-svc
+              port: 8080
+      tls: null
+when forwardAuth enabled, should add middleware and generate Middleware resource:
+  1: |
+    apiVersion: traefik.io/v1alpha1
+    kind: IngressRoute
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: app-name
+        app.kubernetes.io/version: 0.1.0
+        traefik.io/controller: traefik-private
+      name: RELEASE-NAME-public
+    spec:
+      entryPoints:
+        - websecure
+      routes:
+        - kind: Rule
+          match: Host(`test.example.com`) && PathPrefix(`/`)
+          middlewares:
+            - name: RELEASE-NAME-public-forwardauth
+          services:
+            - name: RELEASE-NAME
+              port: 80
+      tls: null
+  2: |
+    apiVersion: traefik.io/v1alpha1
+    kind: Middleware
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: app-name
+        app.kubernetes.io/version: 0.1.0
+        traefik.io/controller: traefik-private
+      name: RELEASE-NAME-public-forwardauth
+    spec:
+      forwardAuth:
+        address: http://authelia.auth.svc.cluster.local/api/authz/forward-auth
+        authResponseHeaders:
+          - Remote-User
+          - Remote-Groups
+          - Remote-Email
+          - Remote-Name
+        trustForwardHeader: true
+when host is FQDN (no domain), should use host directly:
+  1: |
+    apiVersion: traefik.io/v1alpha1
+    kind: IngressRoute
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: app-name
+        app.kubernetes.io/version: 0.1.0
+        traefik.io/controller: traefik-private
+      name: RELEASE-NAME-public
+    spec:
+      entryPoints:
+        - websecure
+      routes:
+        - kind: Rule
+          match: Host(`myapp.example.com`) && PathPrefix(`/`)
+          services:
+            - name: RELEASE-NAME
+              port: 80
+      tls: null

--- a/charts/idp-app/tests/configs_test.yaml
+++ b/charts/idp-app/tests/configs_test.yaml
@@ -415,6 +415,33 @@ tests:
           value: kubernetes.io/basic-auth
         template: configs.yaml
         documentIndex: 0
+  - it: when secret with Opaque type and sealedSecret are both set, sealedSecret takes priority
+    set:
+      configs:
+        sealed-opaque:
+          secret: {}
+          sealedSecret:
+            encryptedData:
+              db_password: AgBy3i4OJSWK
+    asserts:
+      - equal:
+          path: kind
+          value: SealedSecret
+        template: configs.yaml
+        documentIndex: 0
+  - it: when secret with Opaque type and awsSecret are both set, awsSecret takes priority
+    set:
+      configs:
+        aws-opaque:
+          secret: {}
+          awsSecret:
+            arn: arn:aws:iam::123456789012:role/external-secrets
+    asserts:
+      - equal:
+          path: kind
+          value: ExternalSecret
+        template: configs.yaml
+        documentIndex: 0
   - it: when not templated cm, should not call tpl function
     set:
       configs:

--- a/charts/idp-app/tests/traefik-ingress-route_test.yaml
+++ b/charts/idp-app/tests/traefik-ingress-route_test.yaml
@@ -108,6 +108,55 @@ tests:
       - failedTemplate:
           errorMessage: "global.idpAppConfig.clusters.test.domains.nonexistent is not defined"
 
+  - it: when tlsOption is set, should generate TLSOption and reference it in IngressRoute
+    values:
+      - values/service.yaml
+    set:
+      traefikIngressRoutes:
+        public:
+          enabled: true
+          entryPointName: websecure
+          domain: example.com
+          host: test
+          path: /
+          tlsOption:
+            minVersion: VersionTLS12
+            maxVersion: VersionTLS13
+            sniStrict: true
+            cipherSuites:
+              - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+            clientAuth:
+              clientAuthType: VerifyClientCertIfGiven
+              secrets:
+                ca1:
+                  ca.crt: |
+                    -----BEGIN CERTIFICATE-----
+                    MIIBkTCB+wIJAL2BqG0EXAMPLE
+                    -----END CERTIFICATE-----
+    asserts:
+      - matchSnapshot: {}
+
+  - it: when tlsOption clientAuth uses only secretNames, should reference existing secrets
+    values:
+      - values/service.yaml
+    set:
+      traefikIngressRoutes:
+        public:
+          enabled: true
+          entryPointName: websecure
+          domain: example.com
+          host: test
+          path: /
+          tlsOption:
+            minVersion: VersionTLS12
+            clientAuth:
+              clientAuthType: VerifyClientCertIfGiven
+              secretNames:
+                - existing-ca-secret
+                - another-ca-secret
+    asserts:
+      - matchSnapshot: {}
+
   - it: should support external service backend
     set:
       traefikIngressRoutes:

--- a/charts/idp-app/tests/traefik-ingress-route_test.yaml
+++ b/charts/idp-app/tests/traefik-ingress-route_test.yaml
@@ -8,10 +8,10 @@ tests:
     values:
       - values/service.yaml
     set:
-      traefikIngressRoutes:
+      ingressRoutes:
         public:
           enabled: true
-          entryPointName: websecure
+          gatewayName: http-public
           domain: example.com
           host: test
           path: /
@@ -23,10 +23,10 @@ tests:
     values:
       - values/service.yaml
     set:
-      traefikIngressRoutes:
+      ingressRoutes:
         public:
           enabled: true
-          entryPointName: websecure
+          gatewayName: http-public
           domain: example.com
           host: test
           path: /exact
@@ -38,10 +38,10 @@ tests:
     values:
       - values/service.yaml
     set:
-      traefikIngressRoutes:
+      ingressRoutes:
         public:
           enabled: true
-          entryPointName: websecure
+          gatewayName: http-public
           domain: example.com
           host: test
           path: "/api/v[0-9]+"
@@ -53,10 +53,10 @@ tests:
     values:
       - values/service.yaml
     set:
-      traefikIngressRoutes:
+      ingressRoutes:
         public:
           enabled: true
-          entryPointName: websecure
+          gatewayName: http-public
           domain: example.com
           host: test
           path: /
@@ -70,10 +70,10 @@ tests:
     values:
       - values/service.yaml
     set:
-      traefikIngressRoutes:
+      ingressRoutes:
         public:
           enabled: true
-          entryPointName: websecure
+          gatewayName: http-public
           host: myapp.example.com
           path: /
     asserts:
@@ -84,10 +84,10 @@ tests:
       - values/multi.yaml
       - values/service.yaml
     set:
-      traefikIngressRoutes:
+      ingressRoutes:
         public:
           enabled: true
-          entryPointName: websecure
+          gatewayName: http-public
           domain: example.com
           host: __DEPLOYMENT_ID__
           path: /
@@ -98,24 +98,48 @@ tests:
     values:
       - values/service.yaml
     set:
-      traefikIngressRoutes:
+      ingressRoutes:
         public:
           enabled: true
-          entryPointName: websecure
+          gatewayName: http-public
           domain: nonexistent
           path: /
     asserts:
       - failedTemplate:
           errorMessage: "global.idpAppConfig.clusters.test.domains.nonexistent is not defined"
 
+  - it: when gateway controller is not traefik, should fail
+    values:
+      - values/service.yaml
+    set:
+      global:
+        idpAppConfig:
+          clusters:
+            test:
+              httpGateways:
+                http-public:
+                  controller: istio
+                  name: http-public
+                  namespace: dev-gateway
+      ingressRoutes:
+        public:
+          enabled: true
+          gatewayName: http-public
+          domain: example.com
+          host: test
+          path: /
+    asserts:
+      - failedTemplate:
+          errorMessage: "ingressRoute: gateway 'http-public' has controller 'istio', only 'traefik' is supported"
+
   - it: when tlsOption is set, should generate TLSOption and reference it in IngressRoute
     values:
       - values/service.yaml
     set:
-      traefikIngressRoutes:
+      ingressRoutes:
         public:
           enabled: true
-          entryPointName: websecure
+          gatewayName: http-public
           domain: example.com
           host: test
           path: /
@@ -140,10 +164,10 @@ tests:
     values:
       - values/service.yaml
     set:
-      traefikIngressRoutes:
+      ingressRoutes:
         public:
           enabled: true
-          entryPointName: websecure
+          gatewayName: http-public
           domain: example.com
           host: test
           path: /
@@ -159,10 +183,10 @@ tests:
 
   - it: should support external service backend
     set:
-      traefikIngressRoutes:
+      ingressRoutes:
         public:
           enabled: true
-          entryPointName: websecure
+          gatewayName: http-public
           domain: example.com
           host: test
           path: /

--- a/charts/idp-app/tests/traefik-ingress-route_test.yaml
+++ b/charts/idp-app/tests/traefik-ingress-route_test.yaml
@@ -1,0 +1,124 @@
+suite: traefik-ingress-route
+templates:
+  - traefik-ingress-route.yaml
+values:
+  - values/minimum.yaml
+tests:
+  - it: should create IngressRoute
+    values:
+      - values/service.yaml
+    set:
+      traefikIngressRoutes:
+        public:
+          enabled: true
+          entryPointName: websecure
+          domain: example.com
+          host: test
+          path: /
+          pathType: PathPrefix
+    asserts:
+      - matchSnapshot: {}
+
+  - it: should create IngressRoute with Exact pathType
+    values:
+      - values/service.yaml
+    set:
+      traefikIngressRoutes:
+        public:
+          enabled: true
+          entryPointName: websecure
+          domain: example.com
+          host: test
+          path: /exact
+          pathType: Exact
+    asserts:
+      - matchSnapshot: {}
+
+  - it: should create IngressRoute with RegularExpression pathType
+    values:
+      - values/service.yaml
+    set:
+      traefikIngressRoutes:
+        public:
+          enabled: true
+          entryPointName: websecure
+          domain: example.com
+          host: test
+          path: "/api/v[0-9]+"
+          pathType: RegularExpression
+    asserts:
+      - matchSnapshot: {}
+
+  - it: when forwardAuth enabled, should add middleware and generate Middleware resource
+    values:
+      - values/service.yaml
+    set:
+      traefikIngressRoutes:
+        public:
+          enabled: true
+          entryPointName: websecure
+          domain: example.com
+          host: test
+          path: /
+          forwardAuth:
+            enabled: true
+            appName: authelia
+    asserts:
+      - matchSnapshot: {}
+
+  - it: when host is FQDN (no domain), should use host directly
+    values:
+      - values/service.yaml
+    set:
+      traefikIngressRoutes:
+        public:
+          enabled: true
+          entryPointName: websecure
+          host: myapp.example.com
+          path: /
+    asserts:
+      - matchSnapshot: {}
+
+  - it: multi support
+    values:
+      - values/multi.yaml
+      - values/service.yaml
+    set:
+      traefikIngressRoutes:
+        public:
+          enabled: true
+          entryPointName: websecure
+          domain: example.com
+          host: __DEPLOYMENT_ID__
+          path: /
+    asserts:
+      - matchSnapshot: {}
+
+  - it: when domain key is missing from cluster config, should fail
+    values:
+      - values/service.yaml
+    set:
+      traefikIngressRoutes:
+        public:
+          enabled: true
+          entryPointName: websecure
+          domain: nonexistent
+          path: /
+    asserts:
+      - failedTemplate:
+          errorMessage: "global.idpAppConfig.clusters.test.domains.nonexistent is not defined"
+
+  - it: should support external service backend
+    set:
+      traefikIngressRoutes:
+        public:
+          enabled: true
+          entryPointName: websecure
+          domain: example.com
+          host: test
+          path: /
+          service:
+            name: my-external-svc
+            port: 8080
+    asserts:
+      - matchSnapshot: {}

--- a/charts/idp-app/tests/values/examples/comprehensive.yaml
+++ b/charts/idp-app/tests/values/examples/comprehensive.yaml
@@ -29,6 +29,10 @@ global:
             controller: traefik
             name: http-public
             namespace: gateway
+            entryPoints:
+              - websecure
+            labelSelector: {}
+            annotationSelector: {}
         apps:
           authelia:
             traefik:
@@ -53,6 +57,14 @@ global:
       httpRoute:
         enabled: false
         pathType: PathPrefix
+        forwardAuth:
+          enabled: false
+      ingressRoute:
+        enabled: false
+        pathType: PathPrefix
+        tls:
+          secretName: wildcard-tls
+        annotations: {}
         forwardAuth:
           enabled: false
       configs:
@@ -145,6 +157,14 @@ ingress:
   host: my-app         # results in my-app.example.com
 
 httpRoutes:
+  public:
+    enabled: true
+    gatewayName: http-public
+    domain: public
+    host: my-app
+    path: /
+
+ingressRoutes:
   public:
     enabled: true
     gatewayName: http-public

--- a/charts/idp-app/tests/values/examples/multi-cluster.yaml
+++ b/charts/idp-app/tests/values/examples/multi-cluster.yaml
@@ -32,6 +32,8 @@ global:
             controller: traefik
             name: http-public
             namespace: gateway
+            entryPoints:
+              - websecure
         apps:
           authelia:
             traefik:
@@ -56,6 +58,8 @@ global:
             controller: traefik
             name: http-public
             namespace: gateway
+            entryPoints:
+              - websecure
 
 # ---------------------------------------------------------------------------
 # App chart values — these stay identical across clusters

--- a/charts/idp-app/tests/values/examples/multi-deployment.yaml
+++ b/charts/idp-app/tests/values/examples/multi-deployment.yaml
@@ -50,6 +50,14 @@ httpRoutes:
     host: __DEPLOYMENT_ID__
     path: /
 
+ingressRoutes:
+  public:
+    enabled: true
+    gatewayName: http-public
+    domain: example.com
+    host: __DEPLOYMENT_ID__
+    path: /
+
 # ---------------------------------------------------------------------------
 # Shared container spec — inherited by all entries in deployment.multi
 # ---------------------------------------------------------------------------

--- a/charts/idp-app/tests/values/examples/shared-defaults.yaml
+++ b/charts/idp-app/tests/values/examples/shared-defaults.yaml
@@ -39,6 +39,15 @@ global:
         forwardAuth:
           enabled: false
 
+      # Default Traefik IngressRoute settings
+      ingressRoute:
+        enabled: false
+        pathType: PathPrefix
+        tls:
+          secretName: wildcard-tls
+        forwardAuth:
+          enabled: false
+
       # Default config resource settings
       configs:
         externalSecret:

--- a/charts/idp-app/tests/values/minimum.yaml
+++ b/charts/idp-app/tests/values/minimum.yaml
@@ -53,8 +53,9 @@ global:
           websecure:
             entryPoints:
               - websecure
-            tls: {}
             labelSelector:
+              traefik.io/controller: traefik-private
+            annotationSelector:
               traefik.io/controller: traefik-private
         nodePools:
           test1:
@@ -79,6 +80,8 @@ global:
       traefikIngressRoute:
         enabled: false
         pathType: PathPrefix
+        tls:
+          secretName: wildcard-example-com-tls
         annotations: {}
         forwardAuth:
           enabled: false

--- a/charts/idp-app/tests/values/minimum.yaml
+++ b/charts/idp-app/tests/values/minimum.yaml
@@ -49,6 +49,13 @@ global:
                   - 'Remote-Groups'
                   - 'Remote-Email'
                   - 'Remote-Name'
+        traefikEntryPoints:
+          websecure:
+            entryPoints:
+              - websecure
+            tls: {}
+            labelSelector:
+              traefik.io/controller: traefik-private
         nodePools:
           test1:
             nodeSelector:
@@ -67,6 +74,12 @@ global:
         pathType: PathPrefix
         annotations: { }
         #filters: [ ]
+        forwardAuth:
+          enabled: false
+      traefikIngressRoute:
+        enabled: false
+        pathType: PathPrefix
+        annotations: {}
         forwardAuth:
           enabled: false
       ingress:

--- a/charts/idp-app/tests/values/minimum.yaml
+++ b/charts/idp-app/tests/values/minimum.yaml
@@ -19,8 +19,12 @@ global:
             controller: traefik
             name: http-public
             namespace: dev-gateway
+            entryPoints:
+              - websecure
             # traefik can be deployed on cluster multiple times, where it uses label selector to select only specific resources (e.g. middleware) that belong to it
             labelSelector:
+              traefik.io/controller: traefik-private
+            annotationSelector:
               traefik.io/controller: traefik-private
         apps:
           oauth2proxy:
@@ -49,14 +53,6 @@ global:
                   - 'Remote-Groups'
                   - 'Remote-Email'
                   - 'Remote-Name'
-        traefikEntryPoints:
-          websecure:
-            entryPoints:
-              - websecure
-            labelSelector:
-              traefik.io/controller: traefik-private
-            annotationSelector:
-              traefik.io/controller: traefik-private
         nodePools:
           test1:
             nodeSelector:
@@ -77,7 +73,7 @@ global:
         #filters: [ ]
         forwardAuth:
           enabled: false
-      traefikIngressRoute:
+      ingressRoute:
         enabled: false
         pathType: PathPrefix
         tls:

--- a/charts/idp-app/values.yaml
+++ b/charts/idp-app/values.yaml
@@ -36,6 +36,13 @@
 #             name: http-public
 #             namespace: gateway
 #             labelSelector: {}       # Extra labels added to HTTPRoute/Middleware
+#         # Named Traefik Entry Points — referenced by traefikIngressRoutes.*.entryPointName
+#         traefikEntryPoints:
+#           websecure:
+#             entryPoints:
+#               - websecure
+#             tls: {}                    # TLS config for IngressRoute (empty = default cert)
+#             labelSelector: {}          # Extra labels added to IngressRoute/Middleware
 #         # Named apps — referenced by ingress.oauth2ProxyAuth.appName / httpRoutes.*.forwardAuth.appName
 #         apps:
 #           authelia:
@@ -76,6 +83,12 @@
 #         oauth2ProxyAuth:
 #           enabled: false
 #       httpRoute:
+#         enabled: false
+#         pathType: PathPrefix
+#         annotations: {}
+#         forwardAuth:
+#           enabled: false
+#       traefikIngressRoute:
 #         enabled: false
 #         pathType: PathPrefix
 #         annotations: {}
@@ -402,17 +415,26 @@ configs: {}
 #         db_host:   {{ .configSpec.values.dbHost }}
 #         log_level: {{ .configSpec.values.logLevel }}
 #
-#   # Inline Secret — templated: true works exactly the same way; values are
-#   # templated before base64-encoding.
+#   # Inline Secret (Opaque) — `secret: {}` is the only required field to distinguish
+#   # this from a ConfigMap. Values in `content` are stored as-is (the chart base64-encodes
+#   # them automatically; you must NOT pre-encode them).
 #   app-secrets:
 #     secret: {}          # secret: {} = Opaque; secret: {type: kubernetes.io/tls} for other types
+#                         # Note: sealedSecret and awsSecret take priority over secret: {type: Opaque}
+#     content:
+#       db_password: s3cr3t
+#       api_key: mykey
+#     # defaultMode: 0400   # Restrictive permissions recommended for secrets
+#     # restartPodOnUpdate: NameSuffix  # Append content hash to resource name (forces pod restart)
+#
+#   # Inline Secret with templated content — values are templated before base64-encoding.
+#   app-secrets-templated:
+#     secret: {}
 #     templated: true
 #     values:
 #       suffix: "{{ .Release.Name }}"
 #     content:
 #       db_password: "s3cr3t-{{ .configSpec.values.suffix }}"
-#     # defaultMode: 0400   # Restrictive permissions recommended for secrets
-#     # restartPodOnUpdate: NameSuffix  # Append content hash to resource name (forces pod restart)
 #
 #   # AWS Secrets Manager — pulls a secret via External Secrets Operator.
 #   # Does not support templated: true (no content rendered by the chart).
@@ -710,6 +732,58 @@ httpRoutes: {}
 #     #   enabled: true
 #     #   appName: authelia            # Named app from clusters.<cluster>.apps
 #     #   allowedGroups: ["admins"]    # Optional group restriction
+
+# ---------------------------------------------------------------------------
+# Traefik IngressRoutes (traefik.io/v1alpha1)
+# ---------------------------------------------------------------------------
+
+# traefikIngressRoutes — Map of Traefik IngressRoute definitions.
+# Merged with global.idpAppConfig.defaults.traefikIngressRoute.
+# Note: service.enabled must be true (or traefikIngressRoute.service must be set).
+#
+# multi support: when deployment.multi is set, one IngressRoute is created per deployment.
+# Use __DEPLOYMENT_ID__ in host to inject the deployment key into the hostname:
+#   host: __DEPLOYMENT_ID__  →  one.example.com, two.example.com (for multi keys "one", "two")
+traefikIngressRoutes: {}
+# Example IngressRoute configuration:
+# traefikIngressRoutes:
+#   public:
+#     enabled: true
+#     entryPointName: websecure          # [required] Named entry point from clusters.<cluster>.traefikEntryPoints
+#
+#     # Host resolution (same as httpRoutes — domain + host, or host alone):
+#     domain: example.com
+#     host: my-app                       # Results in my-app.example.com
+#     # host: my-app.example.com         # Without domain: used as full FQDN directly
+#
+#     # Domain values may contain a generic <HOST{sep}> placeholder to control separator and position.
+#     # domain: <HOST.>dev.example.com   # host: aaa → aaa.dev.example.com; no host → dev.example.com
+#     # domain: <HOST->dev.example.com   # host: aaa → aaa-dev.example.com; no host → dev.example.com
+#
+#     # __DEPLOYMENT_ID__ placeholder (for deployment.multi):
+#     # host: __DEPLOYMENT_ID__          # replaced with each deployment key → one.example.com, two.example.com
+#
+#     path: /                            # [required] URL path to match
+#     pathType: PathPrefix               # PathPrefix | Exact | RegularExpression
+#
+#     annotations: {}                    # Annotations added to the IngressRoute resource
+#
+#     # Extra Traefik middlewares (appended after forwardAuth if enabled)
+#     # middlewares:
+#     #   - name: my-middleware
+#
+#     # External / override service backend.
+#     # Use when service.enabled is false and you want to route to an existing Service.
+#     # Mutually exclusive with service.enabled — setting both causes a template error.
+#     # service:
+#     #   name: my-external-svc          # [required] Name of the target Service (supports tpl)
+#     #   port: 8080                     # [required] Service port number
+#
+#     # Forward-auth via Traefik Middleware (creates a Middleware resource automatically)
+#     # forwardAuth:
+#     #   enabled: true
+#     #   appName: authelia              # Named app from clusters.<cluster>.apps
+#     #   allowedGroups: ["admins"]      # Optional group restriction
 
 # ---------------------------------------------------------------------------
 # Autoscaling (HorizontalPodAutoscaler)

--- a/charts/idp-app/values.yaml
+++ b/charts/idp-app/values.yaml
@@ -29,20 +29,16 @@
 #                 operator: Equal
 #                 value: worker
 #                 effect: NoSchedule
-#         # Named HTTP Gateways — referenced by httpRoutes.*.gatewayName
+#         # Named HTTP Gateways — referenced by httpRoutes.*.gatewayName / ingressRoutes.*.gatewayName
 #         httpGateways:
 #           http-public:
 #             controller: traefik     # Only "traefik" is currently supported for forwardAuth
 #             name: http-public
 #             namespace: gateway
-#             labelSelector: {}       # Extra labels added to HTTPRoute/Middleware
-#         # Named Traefik Entry Points — referenced by traefikIngressRoutes.*.entryPointName
-#         traefikEntryPoints:
-#           websecure:
-#             entryPoints:
+#             entryPoints:            # Traefik entry points (used by ingressRoutes)
 #               - websecure
-#             labelSelector: {}          # Extra labels added to IngressRoute/Middleware/TLSOption
-#             annotationSelector: {}     # Extra annotations added to IngressRoute/Middleware/TLSOption
+#             labelSelector: {}       # Extra labels added to HTTPRoute/IngressRoute/Middleware/TLSOption
+#             annotationSelector: {}  # Extra annotations added to IngressRoute/Middleware/TLSOption
 #         # Named apps — referenced by ingress.oauth2ProxyAuth.appName / httpRoutes.*.forwardAuth.appName
 #         apps:
 #           authelia:
@@ -88,7 +84,7 @@
 #         annotations: {}
 #         forwardAuth:
 #           enabled: false
-#       traefikIngressRoute:
+#       ingressRoute:
 #         enabled: false
 #         pathType: PathPrefix
 #         tls:
@@ -739,19 +735,19 @@ httpRoutes: {}
 # Traefik IngressRoutes (traefik.io/v1alpha1)
 # ---------------------------------------------------------------------------
 
-# traefikIngressRoutes — Map of Traefik IngressRoute definitions.
-# Merged with global.idpAppConfig.defaults.traefikIngressRoute.
-# Note: service.enabled must be true (or traefikIngressRoute.service must be set).
+# ingressRoutes — Map of Traefik IngressRoute definitions.
+# Merged with global.idpAppConfig.defaults.ingressRoute.
+# Note: service.enabled must be true (or ingressRoute.service must be set).
 #
 # multi support: when deployment.multi is set, one IngressRoute is created per deployment.
 # Use __DEPLOYMENT_ID__ in host to inject the deployment key into the hostname:
 #   host: __DEPLOYMENT_ID__  →  one.example.com, two.example.com (for multi keys "one", "two")
-traefikIngressRoutes: {}
+ingressRoutes: {}
 # Example IngressRoute configuration:
-# traefikIngressRoutes:
+# ingressRoutes:
 #   public:
 #     enabled: true
-#     entryPointName: websecure          # [required] Named entry point from clusters.<cluster>.traefikEntryPoints
+#     gatewayName: http-public            # [required] Named gateway from clusters.<cluster>.httpGateways
 #
 #     # Host resolution (same as httpRoutes — domain + host, or host alone):
 #     domain: example.com

--- a/charts/idp-app/values.yaml
+++ b/charts/idp-app/values.yaml
@@ -41,8 +41,8 @@
 #           websecure:
 #             entryPoints:
 #               - websecure
-#             tls: {}                    # TLS config for IngressRoute (empty = default cert)
-#             labelSelector: {}          # Extra labels added to IngressRoute/Middleware
+#             labelSelector: {}          # Extra labels added to IngressRoute/Middleware/TLSOption
+#             annotationSelector: {}     # Extra annotations added to IngressRoute/Middleware/TLSOption
 #         # Named apps — referenced by ingress.oauth2ProxyAuth.appName / httpRoutes.*.forwardAuth.appName
 #         apps:
 #           authelia:
@@ -91,6 +91,8 @@
 #       traefikIngressRoute:
 #         enabled: false
 #         pathType: PathPrefix
+#         tls:
+#           secretName: wildcard-tls    # Name of Secret containing the TLS certificate
 #         annotations: {}
 #         forwardAuth:
 #           enabled: false
@@ -765,6 +767,32 @@ traefikIngressRoutes: {}
 #
 #     path: /                            # [required] URL path to match
 #     pathType: PathPrefix               # PathPrefix | Exact | RegularExpression
+#
+#     tls:                                # TLS config for IngressRoute
+#       secretName: wildcard-tls         # Name of Secret containing the TLS certificate
+#
+#     # tlsOption — generates a TLSOption resource and auto-references it in IngressRoute tls.options
+#     # tlsOption:
+#     #   minVersion: VersionTLS12
+#     #   maxVersion: VersionTLS13
+#     #   sniStrict: true
+#     #   cipherSuites:
+#     #     - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+#     #   curvePreferences:
+#     #     - CurveP256
+#     #   clientAuth:
+#     #     clientAuthType: VerifyClientCertIfGiven
+#     #     secretNames:                    # Reference pre-existing secrets
+#     #       - existing-secret
+#     #     secrets:                        # Auto-generate secrets from inline CA data
+#     #       ca1:                          # (creates Secret + populates secretNames automatically)
+#     #         ca.crt: |
+#     #           -----BEGIN CERTIFICATE-----
+#     #           ...
+#     #           -----END CERTIFICATE-----
+#     #   alpnProtocols:
+#     #     - h2
+#     #     - http/1.1
 #
 #     annotations: {}                    # Annotations added to the IngressRoute resource
 #

--- a/examples/idp-app-config/values.yaml
+++ b/examples/idp-app-config/values.yaml
@@ -14,8 +14,12 @@ global:
             name: http-public
             namespace: dev-gateway
             controller: traefik
+            entryPoints:
+              - websecure
             # traefik can be deployed on cluster multiple times, where it uses label selector to select only specific resources (e.g. middleware) that belong to it
             labelSelector:
+              traefik.io/controller: traefik-private
+            annotationSelector:
               traefik.io/controller: traefik-private
         apps:
           oauth2proxy:


### PR DESCRIPTION
## Summary

- Added `ingressRoutes` support — creates native Traefik `IngressRoute` CRDs (`traefik.io/v1alpha1`) with the same configuration options as `httpRoutes` (host resolution, service backend, forwardAuth, multi-deployment, annotations)
- Traefik match rule syntax: `Host()` + `PathPrefix()` / `Path()` / `PathRegexp()` mapped from `pathType`
- `TLSOption` resource support with auto-generated `clientAuth` secrets from inline CA data
- `entryPoints`, `annotationSelector` added to `httpGateways` cluster config (no separate `traefikEntryPoints`)
- Gateway controller validation — fails if referenced gateway is not `traefik`
- Snapshot tests covering all scenarios
- Updated examples (comprehensive, multi-cluster, multi-deployment, shared-defaults)
- Chart version bumped to `5.11.0`