### PR TITLE
feat(idp-app)!: introduce statefulset top-level values key

### DIFF
--- a/charts/idp-app/Chart.yaml
+++ b/charts/idp-app/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: idp-app
 description: Base chart
 type: application
-version: 5.15.0
+version: 6.0.0

--- a/charts/idp-app/templates/_config-files.tpl
+++ b/charts/idp-app/templates/_config-files.tpl
@@ -13,7 +13,7 @@ Arguments:
 
 restartPodOnUpdate: hashes are injected via idp-app.injectFromFolderHashes before rendering,
 enabling NameSuffix ConfigMap naming. For PodAnnotation pod restarts, pair with
-idp-app.deployments (or equivalent) in the umbrella chart.
+idp-app.workload (or equivalent) in the umbrella chart.
 */}}
 {{- define "idp-app.configsFromFolders" -}}
 {{- $root := index . 0 -}}

--- a/charts/idp-app/templates/_helpers.tpl
+++ b/charts/idp-app/templates/_helpers.tpl
@@ -41,6 +41,31 @@ Returns YAML for the resolved behavior, or empty string if nothing to render.
 {{- end -}}
 {{- end -}}
 
+{{/*
+Return the active workload kind: "Deployment" or "StatefulSet".
+Fails if both deployment.enabled and statefulset.enabled are true.
+*/}}
+{{- define "idp-app.workloadKind" -}}
+{{- if and .Values.deployment.enabled .Values.statefulset.enabled }}
+  {{- fail "deployment.enabled and statefulset.enabled cannot both be true" }}
+{{- else if .Values.statefulset.enabled -}}
+StatefulSet
+{{- else -}}
+Deployment
+{{- end -}}
+{{- end }}
+
+{{/*
+Return the active workload values map (deployment or statefulset).
+*/}}
+{{- define "idp-app.activeWorkload" -}}
+{{- if .Values.statefulset.enabled -}}
+{{- toYaml .Values.statefulset -}}
+{{- else -}}
+{{- toYaml .Values.deployment -}}
+{{- end -}}
+{{- end }}
+
 {{- define "idp-app.deploymentName" -}}
 {{- $ := index . 0 -}}
 {{- $deploymentKey := index . 1 -}}

--- a/charts/idp-app/templates/_pod.tpl
+++ b/charts/idp-app/templates/_pod.tpl
@@ -89,7 +89,7 @@ spec:
     {{- if $spec.persistentVolumeClaim.claimName }}
     - name: {{ $name }}
       {{ toYaml $spec | nindent 6 }}
-    {{- else if ne $.Values.deployment.kind "StatefulSet" }}
+    {{- else if ne (include "idp-app.workloadKind" $) "StatefulSet" }}
     - name: {{ $name }}
       persistentVolumeClaim:
         claimName: {{ join "-" (compact (list $deploymentName $name)) }}

--- a/charts/idp-app/templates/_workload.tpl
+++ b/charts/idp-app/templates/_workload.tpl
@@ -1,9 +1,9 @@
 {{/*
 Render Deployment/StatefulSet manifests.
-Shared by deployment.yaml (subchart) and umbrella charts.
+Shared by deployment.yaml, statefulset.yaml (subchart) and umbrella charts.
 
 Usage in an umbrella chart template:
-  {{- include "idp-app.deployments" (list . .Values.app) }}
+  {{- include "idp-app.workload" (list . .Values.app) }}
 
 Arguments:
   index 0 — root context (.Files used for fromFolder hash computation when available)
@@ -14,22 +14,20 @@ hashes are computed automatically from .Files — no manual valuesHash needed.
 When called from the subchart directly, .Files has no umbrella files so hash injection is
 skipped (same behaviour as before).
 */}}
-{{- define "idp-app.deployments" -}}
+{{- define "idp-app.workload" -}}
 {{- $root := index . 0 -}}
 {{- $values := index . 1 -}}
 {{- include "idp-app.injectFromFolderHashes" (list $root $values) -}}
 {{- $ctx := set (mustDeepCopy $root) "Values" $values -}}
-{{- $this := $values.deployment -}}
-{{- if not (has $this.kind (list "Deployment" "StatefulSet")) }}
-  {{- fail "deployment.kind must be Deployment or StatefulSet" }}
-{{- end }}
+{{- $kind := include "idp-app.workloadKind" $ctx -}}
+{{- $this := fromYaml (include "idp-app.activeWorkload" $ctx) -}}
 {{- $deployments := default (dict "" $this) $this.multi }}
 {{- range $deploymentKey, $deployment := $deployments }}
 {{- $deploymentName := include "idp-app.deploymentName" (list $ctx $deploymentKey) }}
 {{- if $deployment.staticIps }}
 {{- else }}
 apiVersion: apps/v1
-kind: {{ $this.kind }}
+kind: {{ $kind }}
 metadata:
   name: {{ $deploymentName }}
   labels:
@@ -42,6 +40,7 @@ spec:
   {{- if not $values.autoscaling.enabled }}
   replicas: {{ $values.replicaCount }}
   {{- end }}
+  {{- if eq $kind "Deployment" }}
   {{- with $this.strategy }}
   {{- if not (has .type (list "RollingUpdate" "Recreate")) }}
     {{- fail "deployment.strategy.type must be RollingUpdate or Recreate" }}
@@ -57,13 +56,40 @@ spec:
     rollingUpdate: null
     {{- end }}
   {{- end }}
+  {{- else if eq $kind "StatefulSet" }}
+  {{- with $this.updateStrategy }}
+  updateStrategy:
+    type: {{ .type | default "RollingUpdate" }}
+    {{- if and (eq (.type | default "RollingUpdate") "RollingUpdate") .rollingUpdate }}
+    rollingUpdate:
+      {{- toYaml .rollingUpdate | nindent 6 }}
+    {{- end }}
+  {{- end }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "idp-app.selectorLabels" (list $ctx $deploymentKey) | nindent 6 }}
   revisionHistoryLimit: {{ $this.revisionHistoryLimit }}
+  {{- if eq $kind "StatefulSet" }}
+  serviceName: {{ $this.serviceName | default (printf "%s-headless" $deploymentName) }}
+  {{- with $this.podManagementPolicy }}
+  podManagementPolicy: {{ . }}
+  {{- end }}
+  {{- with $this.minReadySeconds }}
+  minReadySeconds: {{ . }}
+  {{- end }}
+  {{- with $this.ordinals }}
+  ordinals:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $this.persistentVolumeClaimRetentionPolicy }}
+  persistentVolumeClaimRetentionPolicy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
   template:
     {{- include "idp-app.podTemplate" (list $ctx $deploymentKey $deployment) | nindent 4 }}
-  {{- if eq $this.kind "StatefulSet" }}
+  {{- if eq $kind "StatefulSet" }}
   {{- $vctEntries := list }}
   {{- range $volumeName, $volumeSpec := $values.volumes }}
   {{- if and $volumeSpec.persistentVolumeClaim (not $volumeSpec.persistentVolumeClaim.claimName) }}

--- a/charts/idp-app/templates/hpa.yaml
+++ b/charts/idp-app/templates/hpa.yaml
@@ -1,6 +1,7 @@
 {{- if not .Values.debug -}}
-{{- if and $.Values.deployment.enabled .Values.autoscaling.enabled }}
-{{- $deployments := default (dict "" dict) $.Values.deployment.multi }}
+{{- if and (or $.Values.deployment.enabled $.Values.statefulset.enabled) .Values.autoscaling.enabled }}
+{{- $activeWorkload := fromYaml (include "idp-app.activeWorkload" $) }}
+{{- $deployments := default (dict "" dict) $activeWorkload.multi }}
 {{- range $deploymentKey, $deployment := $deployments }}
 {{- $deploymentName := include "idp-app.deploymentName" (list $ $deploymentKey) }}
 apiVersion: autoscaling/v2
@@ -12,7 +13,7 @@ metadata:
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
-    kind: {{ $.Values.deployment.kind }}
+    kind: {{ include "idp-app.workloadKind" $ }}
     name: {{ include "idp-app.fullname" $ }}{{- if $deploymentKey }}-{{ $deploymentKey }}{{- end }}
   minReplicas: {{ required "autoscaling.minReplicas required" $.Values.autoscaling.minReplicas }}
   maxReplicas: {{ required "autoscaling.maxReplicas required" $.Values.autoscaling.maxReplicas }}

--- a/charts/idp-app/templates/pdb.yaml
+++ b/charts/idp-app/templates/pdb.yaml
@@ -1,6 +1,7 @@
 {{- if not .Values.debug -}}
-{{- if and .Values.deployment.enabled .Values.podDisruptionBudget.enabled -}}
-{{- $deployments := default (dict "" dict) $.Values.deployment.multi }}
+{{- if and (or .Values.deployment.enabled .Values.statefulset.enabled) .Values.podDisruptionBudget.enabled -}}
+{{- $activeWorkload := fromYaml (include "idp-app.activeWorkload" $) }}
+{{- $deployments := default (dict "" dict) $activeWorkload.multi }}
 {{- range $deploymentKey, $deployment := $deployments }}
 {{- $deploymentName := include "idp-app.deploymentName" (list $ $deploymentKey) }}
 apiVersion: policy/v1

--- a/charts/idp-app/templates/pvc.yaml
+++ b/charts/idp-app/templates/pvc.yaml
@@ -3,9 +3,10 @@
 {{- range $volumeName, $volumeSpec := . }}
 {{- if $volumeSpec.persistentVolumeClaim }}
 {{- if not $volumeSpec.persistentVolumeClaim.claimName }}
-{{- if ne $.Values.deployment.kind "StatefulSet" }}
+{{- if ne (include "idp-app.workloadKind" $) "StatefulSet" }}
 {{- $pvcSpec := $volumeSpec.persistentVolumeClaim }}
-{{- $deployments := default (dict "" dict) $.Values.deployment.multi }}
+{{- $activeWorkload := fromYaml (include "idp-app.activeWorkload" $) }}
+{{- $deployments := default (dict "" dict) $activeWorkload.multi }}
 {{- range $deploymentKey, $deployment := $deployments }}
 {{- $deploymentName := include "idp-app.deploymentName" (list $ $deploymentKey) }}
 {{- $pvcName := join "-" (compact (list $deploymentName $volumeName)) }}

--- a/charts/idp-app/templates/service-headless.yaml
+++ b/charts/idp-app/templates/service-headless.yaml
@@ -1,11 +1,17 @@
 {{- if not $.Values.debug }}
 {{- $headlessService := $.Values.headlessService }}
+{{- $activeWorkload := fromYaml (include "idp-app.activeWorkload" $) }}
+{{- if $.Values.statefulset.enabled }}
+{{- if not $headlessService.enabled }}
+{{- fail "statefulset: headlessService.enabled must be true when statefulset is enabled" }}
+{{- end }}
+{{- end }}
 {{- if $headlessService.enabled }}
-{{- $deployments := default (dict "" $.Values.deployment) $.Values.deployment.multi }}
+{{- $deployments := default (dict "" $activeWorkload) $activeWorkload.multi }}
 {{- range $deploymentKey, $deployment := $deployments }}
-{{- $deployment = mustMergeOverwrite (deepCopy $.Values.deployment) (deepCopy $deployment) }}
+{{- $deployment = mustMergeOverwrite (deepCopy $activeWorkload) (deepCopy $deployment) }}
 {{- if not (or $deployment.enabled) }}
-{{- fail "headlessService: deployment must be enabled" }}
+{{- fail "headlessService: deployment or statefulset must be enabled" }}
 {{- end }}
 {{- $deploymentName := include "idp-app.deploymentName" (list $ $deploymentKey) }}
 apiVersion: v1

--- a/charts/idp-app/templates/service.yaml
+++ b/charts/idp-app/templates/service.yaml
@@ -1,10 +1,11 @@
 {{- if not .Values.debug -}}
 {{- if .Values.service.enabled }}
-{{- $deployments := default (dict "" $.Values.deployment) $.Values.deployment.multi }}
+{{- $activeWorkload := fromYaml (include "idp-app.activeWorkload" $) }}
+{{- $deployments := default (dict "" $activeWorkload) $activeWorkload.multi }}
 {{- range $deploymentKey, $deployment := $deployments }}
-{{- $deployment = mustMergeOverwrite (deepCopy $.Values.deployment) (deepCopy $deployment) }}
+{{- $deployment = mustMergeOverwrite (deepCopy $activeWorkload) (deepCopy $deployment) }}
 {{- if not (or $deployment.enabled $deployment.staticIps) }}
-{{- fail "service: deployment must be enabled or staticIps specified" }}
+{{- fail "service: deployment or statefulset must be enabled or staticIps specified" }}
 {{- end }}
 {{- $deploymentName := include "idp-app.deploymentName" (list $ $deploymentKey) }}
 apiVersion: v1

--- a/charts/idp-app/templates/statefulset.yaml
+++ b/charts/idp-app/templates/statefulset.yaml
@@ -1,6 +1,6 @@
 {{- if not $.Values.debug -}}
-{{- if $.Values.deployment.enabled }}
-{{- if not $.Values.deployment.managedByUmbrella }}
+{{- if $.Values.statefulset.enabled }}
+{{- if not $.Values.statefulset.managedByUmbrella }}
 {{- include "idp-app.workload" (list $ $.Values) }}
 {{- end }}
 {{- end }}

--- a/charts/idp-app/tests/__snapshot__/example-workload-types_test.yaml.snap
+++ b/charts/idp-app/tests/__snapshot__/example-workload-types_test.yaml.snap
@@ -208,6 +208,63 @@ job:
       ttlSecondsAfterFinished: 300
 statefulset:
   1: |
+    apiVersion: policy/v1
+    kind: PodDisruptionBudget
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: my-app
+        app.kubernetes.io/version: 1.0.0
+      name: RELEASE-NAME
+    spec:
+      minAvailable: 50%
+      selector:
+        matchLabels:
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: my-app
+  2: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: my-app
+        app.kubernetes.io/version: 1.0.0
+      name: RELEASE-NAME-headless
+    spec:
+      clusterIP: None
+      ports:
+        - name: app
+          port: 80
+          protocol: TCP
+          targetPort: app
+      selector:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/name: my-app
+      type: ClusterIP
+  3: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: my-app
+        app.kubernetes.io/version: 1.0.0
+      name: RELEASE-NAME
+    spec:
+      ports:
+        - name: app
+          port: 80
+          protocol: TCP
+          targetPort: app
+      selector:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/name: my-app
+      type: ClusterIP
+  4: |
     apiVersion: apps/v1
     kind: StatefulSet
     metadata:
@@ -224,6 +281,7 @@ statefulset:
         matchLabels:
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: my-app
+      serviceName: RELEASE-NAME-headless
       template:
         metadata:
           labels:
@@ -276,39 +334,3 @@ statefulset:
             resources:
               requests:
                 storage: 10Gi
-  2: |
-    apiVersion: policy/v1
-    kind: PodDisruptionBudget
-    metadata:
-      labels:
-        app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: my-app
-        app.kubernetes.io/version: 1.0.0
-      name: RELEASE-NAME
-    spec:
-      minAvailable: 50%
-      selector:
-        matchLabels:
-          app.kubernetes.io/instance: RELEASE-NAME
-          app.kubernetes.io/name: my-app
-  3: |
-    apiVersion: v1
-    kind: Service
-    metadata:
-      labels:
-        app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: my-app
-        app.kubernetes.io/version: 1.0.0
-      name: RELEASE-NAME
-    spec:
-      ports:
-        - name: app
-          port: 80
-          protocol: TCP
-          targetPort: app
-      selector:
-        app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/name: my-app
-      type: ClusterIP

--- a/charts/idp-app/tests/deployment_test.yaml
+++ b/charts/idp-app/tests/deployment_test.yaml
@@ -290,14 +290,6 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].ports[0].protocol
           value: UDP
-  - it: when deployment.kind is StatefulSet
-    values:
-      - values/deployment.yaml
-      - values/statefulset.yaml
-    asserts:
-      - equal:
-          path: kind
-          value: StatefulSet
   - it: default restartPolicy is undefined
     values:
       - values/deployment.yaml

--- a/charts/idp-app/tests/hpa_test.yaml
+++ b/charts/idp-app/tests/hpa_test.yaml
@@ -97,9 +97,8 @@ tests:
                 value: 5
                 periodSeconds: 60
 
-  - it: when deployment.kind is StatefulSet
+  - it: when statefulset is enabled
     values:
-      - values/deployment.yaml
       - values/autoscaling.yaml
       - values/statefulset.yaml
     asserts:

--- a/charts/idp-app/tests/service_test.yaml
+++ b/charts/idp-app/tests/service_test.yaml
@@ -14,7 +14,7 @@ tests:
       - values/service.yaml
     asserts:
       - failedTemplate:
-          errorMessage: "service: deployment must be enabled or staticIps specified"
+          errorMessage: "service: deployment or statefulset must be enabled or staticIps specified"
   - it: when multi deployment
     values:
       - values/service.yaml

--- a/charts/idp-app/tests/values/examples/workload-types-statefulset.yaml
+++ b/charts/idp-app/tests/values/examples/workload-types-statefulset.yaml
@@ -1,6 +1,8 @@
-deployment:
+statefulset:
   enabled: true
-  kind: StatefulSet
+
+headlessService:
+  enabled: true
 
 service:
   enabled: true

--- a/charts/idp-app/tests/values/statefulset.yaml
+++ b/charts/idp-app/tests/values/statefulset.yaml
@@ -1,2 +1,5 @@
-deployment:
-  kind: StatefulSet
+statefulset:
+  enabled: true
+
+headlessService:
+  enabled: true

--- a/charts/idp-app/values.yaml
+++ b/charts/idp-app/values.yaml
@@ -498,15 +498,15 @@ configs: {}
 #   # Supports templated: true (and values:) — file contents are run through tpl at render time.
 #   # See examples/config-files for a complete example.
 #   #
-#   # restartPodOnUpdate: supported automatically when using idp-app.deployments in the
+#   # restartPodOnUpdate: supported automatically when using idp-app.workload in the
 #   # umbrella chart — file content hash is computed from .Files at render time.
-#   # Without idp-app.deployments, set valuesHash manually (e.g. from CI sha256sum).
+#   # Without idp-app.workload, set valuesHash manually (e.g. from CI sha256sum).
 #   app-folder-config:
 #     fromFolder: configs   # Folder path relative to umbrella chart root
 #     templated: true       # Optional: render file contents as Go templates
 #     values:               # Optional: extra variables accessible as .configSpec.values.*
 #       env: production
-#     restartPodOnUpdate: PodAnnotation  # Auto-computed when using idp-app.deployments
+#     restartPodOnUpdate: PodAnnotation  # Auto-computed when using idp-app.workload
 #     # valuesHash: abc123  # Manual override; takes precedence over auto-computed hash
 #
 #   # Reference an existing Secret — the reference string is always rendered through
@@ -526,6 +526,7 @@ configs: {}
 #                    (one per entry in deployment.multi).
 #       StatefulSet: uses volumeClaimTemplates in the StatefulSet spec so each replica
 #                    gets its own PVC automatically. No standalone PVC is created.
+#                    (one volumeClaimTemplate per entry in statefulset.multi)
 volumes: {}
 # Example volume configurations:
 # volumes:
@@ -560,22 +561,15 @@ volumes: {}
 
 deployment:
   enabled: false
-  # kind — Workload type. Deployment or StatefulSet.
-  # Valid values: Deployment | StatefulSet
-  #
-  # When StatefulSet: volumes with persistentVolumeClaim (without claimName) are rendered
-  # as volumeClaimTemplates in the StatefulSet spec — each replica gets its own PVC.
-  # Volumes with an explicit claimName still work as regular shared pod volumes.
-  kind: Deployment
   # managedByUmbrella — Set to true when an umbrella chart renders the Deployment via
-  # {{- include "idp-app.deployments" (list . .Values.<alias>) }}
+  # {{- include "idp-app.workload" (list . .Values.<alias>) }}
   # Prevents duplicate Deployment output while keeping PDB/HPA/Service resources active.
   managedByUmbrella: false
   annotations: {}
   # revisionHistoryLimit — Number of old ReplicaSets to retain.
   revisionHistoryLimit: 1
 
-  # strategy — Update strategy for Deployment. Ignored for StatefulSet.
+  # strategy — Update strategy for Deployment.
   # https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
   # strategy:
   #   type: RollingUpdate    # RollingUpdate | Recreate
@@ -588,7 +582,7 @@ deployment:
   # Example: staticIps: ["10.0.0.1", "10.0.0.2"]
   #staticIps: []
 
-  # multi — Create multiple Deployments/StatefulSets from one chart release.
+  # multi — Create multiple Deployments from one chart release.
   # Each key becomes a name suffix appended to the release name.
   # The containers map at the multi level is deep-merged over the top-level containers.
   #
@@ -618,6 +612,52 @@ deployment:
   #       path: /
   #
   # See tests/values/examples/multi-deployment.yaml for a full example.
+
+statefulset:
+  enabled: false
+  # NOTE: headlessService.enabled must also be set to true when enabling StatefulSet.
+  # managedByUmbrella — Set to true when an umbrella chart renders the StatefulSet via
+  # {{- include "idp-app.workload" (list . .Values.<alias>) }}
+  # Prevents duplicate StatefulSet output while keeping PDB/HPA/Service resources active.
+  managedByUmbrella: false
+  annotations: {}
+  # revisionHistoryLimit — Number of old StatefulSet revisions to retain.
+  revisionHistoryLimit: 1
+
+  # updateStrategy — Update strategy for StatefulSet.
+  # https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
+  # updateStrategy:
+  #   type: RollingUpdate    # RollingUpdate | OnDelete
+  #   rollingUpdate:
+  #     partition: 0         # Only pods with ordinal >= partition are updated
+  #     maxUnavailable: 1
+
+  # podManagementPolicy — Controls the order of pod creation/deletion.
+  # podManagementPolicy: OrderedReady   # OrderedReady | Parallel
+
+  # ordinals — Control the starting ordinal of the StatefulSet (K8s >= 1.27).
+  # ordinals:
+  #   start: 0
+
+  # minReadySeconds — Minimum seconds a pod must be ready before being considered available.
+  # minReadySeconds: 0
+
+  # persistentVolumeClaimRetentionPolicy — Controls PVC lifecycle on scale/delete.
+  # persistentVolumeClaimRetentionPolicy:
+  #   whenDeleted: Retain    # Retain | Delete
+  #   whenScaled: Retain     # Retain | Delete
+
+  # multi — Create multiple StatefulSets from one chart release.
+  # Each key becomes a name suffix; a matching headless service is also created per key.
+  # The containers map at the multi level is deep-merged over the top-level containers.
+  #
+  # Example:
+  # multi:
+  #   primary: {}
+  #   secondary:
+  #     containers:
+  #       app:
+  #         command: ["replica"]
 
 job:
   enabled: false
@@ -667,7 +707,9 @@ service:
   #     targetPort: metrics
 
 # headlessService — Create a headless Service (clusterIP: None).
-# Useful for StatefulSets to enable DNS-based pod discovery (pod-0.svc, pod-1.svc, ...).
+# Required when statefulset.enabled is true — enables DNS-based pod discovery
+# (pod-0.release-name-headless, pod-1.release-name-headless, ...).
+# Chart will fail if statefulset.enabled is true and headlessService.enabled is false.
 headlessService:
   enabled: false
 

--- a/examples/config-files/templates/deployments.yaml
+++ b/examples/config-files/templates/deployments.yaml
@@ -1,1 +1,1 @@
-{{- include "idp-app.deployments" (list . .Values.app) }}
+{{- include "idp-app.workload" (list . .Values.app) }}


### PR DESCRIPTION
BREAKING CHANGE: deployment.kind: StatefulSet is removed. Use the new top-level statefulset: key instead. headlessService.enabled must be explicitly set to true when statefulset.enabled is true. idp-app.deployments renamed to idp-app.workload.

- Add statefulset: values block with STS-specific fields: updateStrategy, podManagementPolicy, ordinals, minReadySeconds, persistentVolumeClaimRetentionPolicy, multi
- Add statefulset.yaml entry point template
- Rename _deployment.tpl to _workload.tpl; rename helper idp-app.deployments to idp-app.workload
- Add idp-app.workloadKind and idp-app.activeWorkload helpers
- Fix strategy vs updateStrategy, emit serviceName on StatefulSet spec
- service, service-headless, hpa, pdb, pvc route through active workload